### PR TITLE
Feature/jacoco settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 	id "org.asciidoctor.convert" version "1.5.9.2"
 	/** restdocs-api plugin **/
 	id 'com.epages.restdocs-api-spec' version '0.15.1'
+	id 'jacoco'
 	id 'java'
 }
 
@@ -65,9 +66,74 @@ dependencies {
 	asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.3.RELEASE'
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
+
+	// 자동으로 모든 Test 타입의 task에 JacocoTaskExtension을 추가하고, test task에서 그 설정을 변경할 수 있게 합니다.
+	jacoco {
+		destinationFile = file("$buildDir/jacoco/jacoco.exec")
+	}
+
+	// test task를 실행할 때 마다 자동으로 jacoco task 가 실행되도록 함.
+	finalizedBy 'jacocoTestReport'
 }
+
+jacoco {
+	// JaCoCo 버전
+	toolVersion = '0.8.5'
+}
+
+/**
+ * 바이너리 커버리지 결과를 사람이 읽기 좋은 형태의 리포트로 저장합니다.
+ */
+jacocoTestReport {
+	reports {
+		// 원하는 리포트를 켜고 끌 수 있습니다.
+		html.enabled true
+
+		//  각 리포트 타입 마다 리포트 저장 경로를 설정할 수 있습니다.
+		html.destination file("$buildDir/jacocoHtml")
+	}
+}
+
+/**
+ * 커버리지 기준을 만족하는지 확인해 주는 task
+ */
+jacocoTestCoverageVerification {
+	// 이 커버리지 기준은 이 글의 맨 아래에서 다시 설명하겠습니다.
+	violationRules {
+		rule {
+			element = 'CLASS'
+
+			limit {
+				counter = 'BRANCH'
+				value = 'COVEREDRATIO'
+				minimum = 0.50
+			}
+		}
+	}
+
+	finalizedBy 'jacocoTestCoverageVerification'
+}
+
+/**
+ * 매번 Report task와 Verification task를 하나로 묶는 task 입니다. <br>
+ * 실행은 아래와 같이 하면 됩니다.
+ *
+ * ./gradlew tasks
+ */
+task testCoverage(type: Test) {
+	group 'verification'
+	description 'Runs the unit tests with coverage'
+
+	dependsOn(':test',
+			':jacocoTestReport',
+			':jacocoTestCoverageVerification')
+
+	tasks['jacocoTestReport'].mustRunAfter(tasks['test'])
+	tasks['jacocoTestCoverageVerification'].mustRunAfter(tasks['jacocoTestReport'])
+}
+
 
 /**
  * Querydsl config

--- a/build.gradle
+++ b/build.gradle
@@ -92,15 +92,36 @@ jacocoTestReport {
 		html.enabled true
 
 		//  각 리포트 타입 마다 리포트 저장 경로를 설정할 수 있습니다.
-		html.destination file("$buildDir/jacocoHtml")
+		html.destination file("$buildDir/jacocoReportsHtml")
 	}
+
+	// jacocoTestCoverageVerification:: "Qdomain 커버리지에서도 제외" jacocoTestReport:: "Qdomain 결과에서도 제외"
+	def Qdomains = []
+	for(qPattern in "**/QA" .. "**/QZ"){
+		Qdomains.add(qPattern+"*")
+	}
+
+	afterEvaluate {
+
+		classDirectories.setFrom(files(classDirectories.files.collect {
+			fileTree(dir: it,
+					exclude: [] + Qdomains)
+		}))
+	}
+
 }
 
 /**
  * 커버리지 기준을 만족하는지 확인해 주는 task
  */
 jacocoTestCoverageVerification {
-	// 이 커버리지 기준은 이 글의 맨 아래에서 다시 설명하겠습니다.
+
+	// Qdomain 을 for loop 를 통해 excludes 시킴
+	def Qdomains = []
+	for (qPattern in "*.QA".."*.QZ") {  // qPattern = "*.QA","*.QB","*.QC", ... "*.QZ"
+		Qdomains.add(qPattern + "*")
+	}
+
 	violationRules {
 		rule {
 			element = 'CLASS'
@@ -110,6 +131,8 @@ jacocoTestCoverageVerification {
 				value = 'COVEREDRATIO'
 				minimum = 0.50
 			}
+
+			excludes = [] + Qdomains
 		}
 	}
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ dependencies {
 	/** querydsl **/
 	implementation("com.querydsl:querydsl-jpa")
 	implementation("com.querydsl:querydsl-apt")
+    implementation 'org.junit.jupiter:junit-jupiter:5.7.0'
+	implementation 'org.junit.jupiter:junit-jupiter:5.7.0'
+	implementation 'org.junit.jupiter:junit-jupiter:5.7.0'
+	implementation 'org.junit.jupiter:junit-jupiter:5.7.0'
+	implementation 'org.junit.jupiter:junit-jupiter:5.7.0'
 	/** querydsl in test **/
 	testCompileOnly("org.projectlombok:lombok")
 	testAnnotationProcessor("org.projectlombok:lombok")

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+#lombok 에 의해 generate 된 메소드는 테스트 검증에서 제외된다.
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/site/hirecruit/hr/domain/anonymous/dto/AnonymousDto.java
+++ b/src/main/java/site/hirecruit/hr/domain/anonymous/dto/AnonymousDto.java
@@ -1,0 +1,40 @@
+package site.hirecruit.hr.domain.anonymous.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.hirecruit.hr.domain.anonymous.entity.AnonymousEntity;
+
+import javax.validation.constraints.NotBlank;
+import java.util.UUID;
+
+@NoArgsConstructor
+public class AnonymousDto {
+
+    @Getter
+    @NoArgsConstructor
+    static class AnonymousRequestDto {
+
+        @NotBlank
+        private String name;
+
+        @NotBlank
+        private String email;
+
+        @Builder
+        public AnonymousRequestDto(String name, String email) {
+            this.name = name;
+            this.email = email;
+        }
+
+        public AnonymousEntity toEntity(AnonymousRequestDto anonymousRequestDto){
+            return AnonymousEntity.builder()
+                    .anonymousUUID(UUID.randomUUID().toString())
+                    .name(anonymousRequestDto.getName())
+                    .email(anonymousRequestDto.getEmail())
+                    .emailCertified(false)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/anonymous/entity/AnonymousEntity.java
+++ b/src/main/java/site/hirecruit/hr/domain/anonymous/entity/AnonymousEntity.java
@@ -1,0 +1,40 @@
+package site.hirecruit.hr.domain.anonymous.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+/**
+ * @version 1.0.0
+ * @author 전지환
+ */
+@Table
+@Entity(name = "anonymous")
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnonymousEntity {
+
+    @Id
+    @Column(name = "anonymous_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long anonymousId;
+
+    @NotNull
+    @Column(name = "anonymous_uuid")
+    private String anonymousUUID;
+
+    @NotNull
+    @Column(name = "name")
+    private String name;
+
+    @NotNull
+    @Column(name = "email")
+    private String email;
+
+    @NotNull
+    @Column(name = "email_certified")
+    private boolean email_certified;
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/anonymous/entity/AnonymousEntity.java
+++ b/src/main/java/site/hirecruit/hr/domain/anonymous/entity/AnonymousEntity.java
@@ -35,6 +35,6 @@ public class AnonymousEntity {
 
     @NotNull
     @Column(name = "email_certified")
-    private boolean email_certified;
+    private boolean emailCertified;
 
 }

--- a/src/main/java/site/hirecruit/hr/domain/anonymous/repository/AnonymousRepository.java
+++ b/src/main/java/site/hirecruit/hr/domain/anonymous/repository/AnonymousRepository.java
@@ -1,0 +1,14 @@
+package site.hirecruit.hr.domain.anonymous.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import site.hirecruit.hr.domain.anonymous.entity.AnonymousEntity;
+
+/**
+ * @version 1.0.0
+ * @author 전지환
+ */
+@Repository
+public interface AnonymousRepository extends JpaRepository<AnonymousEntity, Long> {
+
+}

--- a/src/test/java/site/hirecruit/hr/domain/anonymous/entity/AnonymousEntityTest.java
+++ b/src/test/java/site/hirecruit/hr/domain/anonymous/entity/AnonymousEntityTest.java
@@ -1,0 +1,38 @@
+package site.hirecruit.hr.domain.anonymous.entity;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import site.hirecruit.hr.domain.anonymous.repository.AnonymousRepository;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Slf4j
+@DataJpaTest
+class AnonymousEntityTest {
+
+    @Autowired
+    private AnonymousRepository anonymousRepository;
+
+    @Test
+    @DisplayName("AnonymousEntity 가 정상적으로 생성된다.")
+    void anonymousEntity_working_normally(){
+        final AnonymousEntity jyeonjyan = AnonymousEntity.builder()
+                .anonymousId(null)
+                .anonymousUUID(UUID.randomUUID().toString())
+                .name("jyeonjyan")
+                .email("jyeonjyan.dev@gmail.com")
+                .emailCertified(false)
+                .build();
+
+        final AnonymousEntity save = anonymousRepository.save(jyeonjyan);
+
+        assertEquals("jyeonjyan", save.getName());
+        assertNotNull(save.getAnonymousUUID());
+    }
+}


### PR DESCRIPTION
## jacoco settings
- QClass test coverage, reports 대상에서 제외 함.

## uses
- `build/jacocoReportsHtml/index.html`

## Help 

- 발생원인
Lombok에 의해 generate 된 method를 테스트 대상에서 제외하기 위해 
`root/lombok.config` 에 `lombok.addLombokGeneratedAnnotation = true` 설정했다.

- 문제
엔티티 테스트 커버리지 자체가 안보임.. 😥
