### PR TITLE
Session 인증/인가 완료

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
@@ -5,6 +5,11 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
 import java.util.Map;
 
+/**
+ * Oauth2 클리아이너트의 정보를 담고 있는 객체
+ *
+ * @author 정시원
+ */
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE) @AllArgsConstructor
 public class OAuthAttributes {

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
@@ -1,6 +1,7 @@
 package site.hirecruit.hr.domain.auth.dto;
 
 import lombok.*;
+import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
 import java.util.Map;
 
@@ -13,7 +14,7 @@ public class OAuthAttributes {
     private Long id;
     private String name;
     private String email;
-    private String pictureUri;
+    private String profileUri;
 
     public static OAuthAttributes of(final String registrationId,
                                      final String userNameAttributeName,
@@ -29,7 +30,18 @@ public class OAuthAttributes {
                 .id(Long.getLong((String) attributes.get(userNameAttributeName)))
                 .name((String) attributes.get("name"))
                 .email((String) attributes.get("email"))
-                .pictureUri((String) attributes.get("picture"))
+                .profileUri((String) attributes.get("picture"))
+                .build();
+    }
+
+    public WorkerEntity toEntity(WorkerEntity.Role role){
+        return WorkerEntity.builder()
+                .githubId(id)
+                .email(email)
+                .name(name)
+                .profileUri(profileUri)
+                .company((String) attributes.get("company"))
+                .role(role)
                 .build();
     }
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
@@ -27,10 +27,10 @@ public class OAuthAttributes {
         return OAuthAttributes.builder()
                 .attributes(attributes)
                 .userNameAttributeName(userNameAttributeName)
-                .id(Long.getLong((String) attributes.get(userNameAttributeName)))
+                .id(Integer.toUnsignedLong((Integer) attributes.get(userNameAttributeName)))
                 .name((String) attributes.get("name"))
                 .email((String) attributes.get("email"))
-                .profileUri((String) attributes.get("picture"))
+                .profileUri((String) attributes.get("avatar_url"))
                 .build();
     }
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.java
@@ -1,0 +1,37 @@
+package site.hirecruit.hr.domain.auth.dto;
+
+import lombok.*;
+
+import java.util.Map;
+
+@Getter @Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE) @AllArgsConstructor
+public class OAuthAttributes {
+
+    private Map<String, Object> attributes;
+    private String userNameAttributeName;
+    private Long id;
+    private String name;
+    private String email;
+    private String pictureUri;
+
+    public static OAuthAttributes of(final String registrationId,
+                                     final String userNameAttributeName,
+                                     final Map<String, Object> attributes){
+        return ofGithub(userNameAttributeName, attributes);
+    }
+
+    private static OAuthAttributes ofGithub(final String userNameAttributeName,
+                                            Map<String, Object> attributes) {
+        return OAuthAttributes.builder()
+                .attributes(attributes)
+                .userNameAttributeName(userNameAttributeName)
+                .id(Long.getLong((String) attributes.get(userNameAttributeName)))
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .pictureUri((String) attributes.get("picture"))
+                .build();
+    }
+
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/SessionUser.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/SessionUser.java
@@ -1,5 +1,7 @@
 package site.hirecruit.hr.domain.auth.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -9,8 +11,9 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
 import java.io.Serializable;
 
-@Getter
+@Getter @Builder
 @Component
+@AllArgsConstructor
 @Scope(value = WebApplicationContext.SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class SessionUser implements Serializable {
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/SessionUser.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/SessionUser.java
@@ -11,6 +11,11 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
 import java.io.Serializable;
 
+/**
+ * 로그인 시 session에 저장될 정보를 담고있는 객체
+ *
+ * @author 정시원
+ */
 @Getter @Builder
 @Component
 @AllArgsConstructor

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/SessionUser.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/SessionUser.java
@@ -1,0 +1,31 @@
+package site.hirecruit.hr.domain.auth.dto;
+
+import lombok.Getter;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
+
+import java.io.Serializable;
+
+@Getter
+@Component
+@Scope(value = WebApplicationContext.SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class SessionUser implements Serializable {
+
+    private final Long userId;
+    private final String name;
+    private final String email;
+    private final String profileUri;
+    private final WorkerEntity.Role role;
+
+    public SessionUser(WorkerEntity worker){
+        this.userId = worker.getWorkerId();
+        this.name = worker.getName();
+        this.email = worker.getEmail();
+        this.profileUri = worker.getProfileUri();
+        this.role = worker.getRole();
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
@@ -59,7 +59,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         // 만약 서비스를 처음 사용하는 사용자라면
         if(userRegistrationService.isFirst(attributes.getId()))
             userRegistrationService.registration(attributes)
-                    .orElseThrow(() -> new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_CLIENT));
+                    .orElseThrow(() ->
+                            new NullPointerException("WorkerEntity cannot be null. Because the WorkerEntity should be saved. Something was wrong"));
 
         final SessionUser loginUser = userAuthService.login(attributes); // 로그인
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
@@ -20,6 +20,7 @@ import java.util.Collections;
  * 실제 OAuth 로직을 작성하는 서비스 (Github기준으로 작성해서 확장성 1도 없음)
  *
  * @version 1.0
+ * @author 정시원
  */
 @Slf4j
 @Service

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
@@ -26,11 +26,11 @@ import java.util.Collections;
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateOAuth2UserService;
-    private final UserRegistrationService userRegistrationService;
+    private final UserRegistrationGithubServiceImpl userRegistrationService;
     private final UserAuthService userAuthService;
 
     @Autowired
-    public CustomOAuth2UserService(UserRegistrationService userRegistrationService, UserAuthService userAuthService) {
+    public CustomOAuth2UserService(UserRegistrationGithubServiceImpl userRegistrationService, UserAuthService userAuthService) {
         this.delegateOAuth2UserService = new DefaultOAuth2UserService();
         this.userRegistrationService = userRegistrationService;
         this.userAuthService = userAuthService;

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.java
@@ -1,38 +1,71 @@
 package site.hirecruit.hr.domain.auth.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes;
+import site.hirecruit.hr.domain.auth.dto.SessionUser;
+
+import java.util.Collections;
 
 /**
- * 실제 OAuth 로직을 작성하는 서비스
+ * 실제 OAuth 로직을 작성하는 서비스 (Github기준으로 작성해서 확장성 1도 없음)
  *
  * @version 1.0
  */
+@Slf4j
 @Service
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateOAuth2UserService;
+    private final UserRegistrationService userRegistrationService;
+    private final UserAuthService userAuthService;
 
     @Autowired
-    public CustomOAuth2UserService() {
+    public CustomOAuth2UserService(UserRegistrationService userRegistrationService, UserAuthService userAuthService) {
         this.delegateOAuth2UserService = new DefaultOAuth2UserService();
-    }
-
-    public CustomOAuth2UserService(
-            OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateOAuth2UserService
-    ) {
-        this.delegateOAuth2UserService = delegateOAuth2UserService;
+        this.userRegistrationService = userRegistrationService;
+        this.userAuthService = userAuthService;
     }
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        return null;
+        final OAuth2User oAuth2User = delegateOAuth2UserService.loadUser(userRequest); // 로그인을 시도한 User의 정보
+        final String registrationId = userRequest.getClientRegistration().getRegistrationId(); // OAuth2 벤더
+        final String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        log.debug("registrationId = '{}'", registrationId);
+        log.debug("userNameAttributeName = '{}'", userNameAttributeName);
+        log.debug("oAuth2User.getAttributes = '{}'", Collections.unmodifiableMap(oAuth2User.getAttributes()));
+
+        final OAuthAttributes attributes = OAuthAttributes.of(
+                registrationId,
+                userNameAttributeName,
+                oAuth2User.getAttributes()
+        );
+
+        // 만약 서비스를 처음 사용하는 사용자라면
+        if(userRegistrationService.isFirst(attributes.getId()))
+            userRegistrationService.registration(attributes)
+                    .orElseThrow(() -> new OAuth2AuthenticationException(OAuth2ErrorCodes.INVALID_CLIENT));
+
+        final SessionUser loginUser = userAuthService.login(attributes); // 로그인
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(loginUser.getRole().getRole())),
+                attributes.getAttributes(),
+                attributes.getUserNameAttributeName()
+        );
     }
-
-
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
@@ -1,0 +1,14 @@
+package site.hirecruit.hr.domain.auth.service;
+
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes;
+import site.hirecruit.hr.domain.auth.dto.SessionUser;
+
+public interface UserAuthService {
+
+    /**
+     * 세션을 이용한 로그인을 진행한다.
+     *
+     * @return 세션에 저장된 데이터
+     */
+    SessionUser login(OAuthAttributes oAuthAttributes);
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
@@ -1,5 +1,6 @@
 package site.hirecruit.hr.domain.auth.service;
 
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes;
 import site.hirecruit.hr.domain.auth.dto.SessionUser;
 
@@ -10,5 +11,5 @@ public interface UserAuthService {
      *
      * @return 세션에 저장된 데이터
      */
-    SessionUser login(OAuthAttributes oAuthAttributes);
+    SessionUser login(OAuthAttributes oAuthAttributes) throws OAuth2AuthenticationException;
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
@@ -10,7 +10,7 @@ import site.hirecruit.hr.domain.auth.dto.SessionUser;
  * @author 정시원
  * @see UserAuthServiceImpl
  */
-public interface UserAuthService {
+interface UserAuthService {
 
     /**
      * 세션을 이용한 로그인을 진행한다.

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.java
@@ -4,6 +4,12 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes;
 import site.hirecruit.hr.domain.auth.dto.SessionUser;
 
+/**
+ * 인증(로그인)를 진행하는 서비스
+ *
+ * @author 정시원
+ * @see UserAuthServiceImpl
+ */
 public interface UserAuthService {
 
     /**

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthServiceImpl.java
@@ -1,2 +1,42 @@
-package site.hirecruit.hr.domain.auth.service;public class UserAuthServiceImpl {
+package site.hirecruit.hr.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.stereotype.Service;
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes;
+import site.hirecruit.hr.domain.auth.dto.SessionUser;
+import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
+import site.hirecruit.hr.domain.worker.repository.WorkerRepository;
+
+import javax.servlet.http.HttpSession;
+
+@RequiredArgsConstructor
+@Service
+public class UserAuthServiceImpl implements UserAuthService {
+
+    private final WorkerRepository workerRepository;
+    private final HttpSession httpSession;
+
+    /**
+     * DB에 유저가 있는지 조회 후 성공적으로 완료되면 login을 진행한다. <br>
+     * login 성공시 {@link SessionUser} 객체가 "user" 라는 이름으로 세션에 저장됩니다.
+     */
+    @Override
+    public SessionUser login(OAuthAttributes oAuthAttributes) {
+
+        final WorkerEntity user = workerRepository.findByGithubId(oAuthAttributes.getId())
+                .orElseThrow(() -> new OAuth2AuthenticationException("User not found"));
+
+        final SessionUser sessionUser = SessionUser.builder()
+                .userId(user.getWorkerId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .profileUri(user.getProfileUri())
+                .role(user.getRole())
+                .build();
+
+        httpSession.setAttribute("user", sessionUser);
+
+        return sessionUser;
+    }
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthServiceImpl.java
@@ -1,0 +1,2 @@
+package site.hirecruit.hr.domain.auth.service;public class UserAuthServiceImpl {
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthServiceImpl.java
@@ -12,7 +12,7 @@ import javax.servlet.http.HttpSession;
 
 @RequiredArgsConstructor
 @Service
-public class UserAuthServiceImpl implements UserAuthService {
+class UserAuthServiceImpl implements UserAuthService {
 
     private final WorkerRepository workerRepository;
     private final HttpSession httpSession;

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationGithubServiceImpl.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationGithubServiceImpl.java
@@ -1,0 +1,30 @@
+package site.hirecruit.hr.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes;
+import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
+import site.hirecruit.hr.domain.worker.repository.WorkerRepository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class UserRegistrationGithubServiceImpl implements UserRegistrationService {
+
+    private final WorkerRepository workerRepository;
+
+    @Override
+    public boolean isFirst(Long id) {
+        return !workerRepository.existsByGithubId(id);
+    }
+
+    @Override
+    public Optional<WorkerEntity> registration(OAuthAttributes oAuthAttributes) {
+        final WorkerEntity workerEntity = oAuthAttributes
+                .toEntity(WorkerEntity.Role.GUEST);
+        final WorkerEntity savedWorkerEntity = workerRepository.save(workerEntity);
+        return Optional.of(savedWorkerEntity);
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationGithubServiceImpl.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationGithubServiceImpl.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
-public class UserRegistrationGithubServiceImpl implements UserRegistrationService {
+class UserRegistrationGithubServiceImpl implements UserRegistrationService {
 
     private final WorkerRepository workerRepository;
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.java
@@ -6,6 +6,12 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
 import java.util.Optional;
 
+/**
+ * 유저의 회원가입을 담당하는 서비스
+ *
+ * @author 정시원
+ * @see UserRegistrationGithubServiceImpl
+ */
 interface UserRegistrationService {
 
     /**

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.java
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.java
@@ -1,0 +1,27 @@
+package site.hirecruit.hr.domain.auth.service;
+
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes;
+import site.hirecruit.hr.domain.auth.dto.SessionUser;
+import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
+
+import java.util.Optional;
+
+interface UserRegistrationService {
+
+    /**
+     * 서비스를 처음 이용하는지 검증하는 메서드
+     *
+     * @param id - OAuth인증 식별자 (유일함) ex. github_id
+     */
+    boolean isFirst(Long id);
+
+    /**
+     * 회원가입 시 role type은 {@link WorkerEntity.Role#GUEST}로 저장된다. <br>
+     * 그 후 추가적인 정보를 입력해 프로필을 업데이트 하면 그 때 {@link WorkerEntity.Role#CLIENT}로 변경
+     *
+     * @param oAuthAttributes OAuth 사용자의 첫 회원가입 정보가 담겨있는 메서드
+     * @return 회원가입이 완료된 WorkerEntity
+     */
+    Optional<WorkerEntity> registration(OAuthAttributes oAuthAttributes);
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.java
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.java
@@ -15,6 +15,7 @@ import javax.persistence.Id;
 @AllArgsConstructor
 public class WorkerEntity {
 
+    @Getter
     @RequiredArgsConstructor
     public enum Role{
         GUEST("ROLE_GUEST", "게스트"), // 인증이 안된 직장인

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.java
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.java
@@ -3,13 +3,9 @@ package site.hirecruit.hr.domain.worker.entity;
 
 import lombok.*;
 
-import javax.management.relation.Role;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
-@Entity
+@Entity @Table(name = "workder")
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -29,6 +25,8 @@ public class WorkerEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long workerId;
 
+    private Long githubId;
+
     private String email;
 
     private String name;
@@ -41,6 +39,7 @@ public class WorkerEntity {
 
     private String introduction;
 
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     public void updateRole(Role role){

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.java
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.java
@@ -3,5 +3,5 @@ package site.hirecruit.hr.domain.worker.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
-public interface MentorRepository extends JpaRepository<WorkerEntity, Long> {
+public interface WorkerRepository extends JpaRepository<WorkerEntity, Long> {
 }

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.java
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.java
@@ -3,5 +3,10 @@ package site.hirecruit.hr.domain.worker.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
+import java.util.Optional;
+
 public interface WorkerRepository extends JpaRepository<WorkerEntity, Long> {
+    boolean existsByGithubId(Long id);
+
+    Optional<WorkerEntity> findByGithubId(long githubId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,4 @@ spring:
 logging:
   level:
     org.hibernate.type.descriptor.sql : trace
+    site.hirecruit.hr : debug


### PR DESCRIPTION
## 개요 
session 인증/인가 완료했습니다.

- `/oauth2/authorization/github` 에서 oauth2로그인을 진행할 수 있습니다. 
  - oauth2 로그인 후 `localhost:8080/` 로 리다이렉트 됩니다.(임시)
  - oauth2 로그인 후 session쿠키를 발급합니다.
- 로그인시 `user`라는 이름으로 `SessionUser`객체가 저장됩니다.
- 첫 oauth2로그인 시 `worker`의 권한은 `GEUST`로 지정됩니다.
   > github 로그인 시 한정적인 정보만 저장되므로 첫 회원가입 후 `worker`정보를 업데이트 하는 API가 필요함(만들 예정)
- 인증/인가는 `CustomOAuth2UserService`에서 담당합니다.

### etc
- 로깅 레벨을 debug로 설정했습니다.

## 앞으로 할 일
- 테스트 코드 작성
- 처음 로그인 시 `worker`의 정보를 업데이트 하는 API 작성
- session 관련 설정 추가