### PR TITLE
local프로필 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ out/
 .vscode/
 
 ### Github OAuth property ###
-**/resources/application-github-oauth.yml
+**/resources/oauth

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ allOpen {
 	annotation("javax.persistence.Entity")
 	annotation("javax.persistence.MappedSuperclass")
 	annotation("javax.persistence.Embeddable")
+	annotation("org.springframework.context.annotation.Configuration")
 }
 
 group = 'site.hirecruit'

--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
 	/** *.adoc file {snippets} auto setting **/
 	asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor:2.0.3.RELEASE'
 	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+	/** embedded redis link: https://github.com/kstyrc/embedded-redis **/
+	compileOnly 'it.ozimov:embedded-redis:0.7.2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ dependencies {
 
 	/** embedded redis link: https://github.com/kstyrc/embedded-redis **/
 	compileOnly 'it.ozimov:embedded-redis:0.7.2'
+
+	/** kotlin logger **/
+	implementation 'io.github.microutils:kotlin-logging-jvm:2.1.21'
 }
 
 test {

--- a/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
@@ -1,12 +1,14 @@
 package site.hirecruit.hr.global.config
 
-import org.slf4j.LoggerFactory
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import redis.embedded.RedisServer
 import javax.annotation.PostConstruct
 import javax.annotation.PreDestroy
+
+private val log = KotlinLogging.logger {}
 
 /**
  * Embedded redis config
@@ -20,9 +22,6 @@ import javax.annotation.PreDestroy
 class EmbeddedRedisConfig(
     @Value("\${spring.redis.port}") val redisPort: Int
 ) {
-
-    private val log = LoggerFactory.getLogger(this.javaClass)
-
     init {
         log.info("embedded redis will start port = '{}'", redisPort)
     }

--- a/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
@@ -1,4 +1,44 @@
 package site.hirecruit.hr.global.config
 
-class EmbeddedRedisConfig {
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import redis.embedded.RedisServer
+import javax.annotation.PostConstruct
+import javax.annotation.PreDestroy
+
+/**
+ * Embedded redis config
+ *
+ * 프로필이 'local'일 떄 작동합니다.
+ *
+ * @author 정시원
+ */
+@Configuration
+@Profile("local")
+class EmbeddedRedisConfig(
+    @Value("\${spring.redis.port}") val redisPort: Int
+) {
+
+    private val log = LoggerFactory.getLogger(this.javaClass)
+
+    init {
+        log.info("embedded redis will start port = '{}'", redisPort)
+    }
+
+    lateinit var redisServer: RedisServer
+
+    @PostConstruct
+    fun redisServer() {
+        redisServer = RedisServer(redisPort)
+        redisServer.start()
+        log.info("embedded redis started successfully")
+    }
+
+    @PreDestroy
+    fun stopRedis() {
+        redisServer.stop()
+        log.info("embedded redis stopped successfully")
+    }
 }

--- a/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
@@ -1,0 +1,4 @@
+package site.hirecruit.hr.global.config
+
+class EmbeddedRedisConfig {
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,59 @@
+server:
+  port: 8080
+
+  # UTF-8 사용
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+spring:
+  config:
+    import: classpath:application-github-oauth.yml
+
+  session:
+    store-type: redis
+    redis:
+      flush-mode: on_save
+      namespace: spring:session # redis에 세션 저장시 네임스페이스
+
+  redis:
+    host: localhost
+    password:
+    port: 6379
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  #H2 DataBase
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: true
+
+  #DB 설정
+  datasource:
+    url: jdbc:h2:mem:HR
+    driver-class-name: org.h2.Driver
+    username: sa
+
+  ### JPA 설정 ###
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        hbm2ddl:
+          auto: create
+    show-sql: true
+
+### Logging ###
+logging:
+  level:
+    org.hibernate.type.descriptor.sql : trace
+    site.hirecruit.hr : debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ server:
 
 spring:
   config:
-    import: classpath:application-github-oauth.yml
+    import: classpath:oauth/github-oauth.yml
 
   session:
     store-type: redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,8 @@ server:
       force: true
 
 spring:
-  profiles:
-    include: github-oauth
+  config:
+    import: classpath:application-github-oauth.yml
 
   session:
     store-type: redis

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ server:
 
 spring:
   config:
-    import: classpath:application-github-oauth.yml
+    import: classpath:oauth/github-oauth.yml
 
   session:
     store-type: redis


### PR DESCRIPTION
## 개요
프로젝트가 redis혹은 외부 db에 영향을 받아 실행되지 않고, 바로 프로젝트가 실행될 수 있도록 하는 'local' 프로필을 생성했습니다.
> 이로 인해 local test를 이용해서 test를 진행하면 외부환경에 영향을 받지 않아 테스트가 수월해질 거 같네요

## 주요 작업 내용
- Embedded Redis를 위한 `embedded-redis`의존성 추가 및 설정을 위한` EmbeddedRedisConfig`추가
- `local`프로필을 위한 `application.yml`작성

## 추가적인 작업 내용
- logging을 위한  `kotlin-logging-jvm`의존성 추가 및 적용 
  > [EmbeddedRedisConfig.kt](https://github.com/themoment-team/HiRecruit-server/pull/14/files#diff-72fddf550d04dcfbcec704211e854ff32a66a6159e4529998c9de96f541bbd35R11) 여기에서 사용했어요!
- spring.profiles 속성이 deprecate되어  `spring.config.import`를 사용함
- `application-github-oauth.yml`를 `github-oauth.yml`로 변경 후 `resource/oauth`로 변경
   > application.yml은 `-`뒤에 프로필 명을 적지만 `application-github-oauth.yml`는 프로필이 아닌 속성을 나눈 yml이므로 파일명을 변경하게 되었습니다.

## PR merge후 해야 하는 작업
`application-github-oauth.yml`를 `github-oauth.yml`로 변경 후 resource 하위에 oauth 디렉토리를 생성한 후 생성한 디렉토리에 `github-oauth.yml`를 넣어주세요