### PR TITLE
Worker도메인 관련 코드 kotlin으로 마이그레이션

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.java
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.java
@@ -5,7 +5,8 @@ import lombok.*;
 
 import javax.persistence.*;
 
-@Entity @Table(name = "workder")
+@Deprecated
+@Entity @Table(name = "worker")
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -1,0 +1,39 @@
+package site.hirecruit.hr.domain.worker.entity
+
+import javax.persistence.*
+
+@Entity @Table(name = "worker")
+class WorkerEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var workerId: Long? = null
+
+    var githubId: Long? = null
+
+    val email: String? = null
+
+    var name: String? = null
+
+    var profileUri: String? = null
+
+    var company: String? = null
+
+    var location: String? = null
+
+    var introduction: String? = null
+
+    @Enumerated(EnumType.STRING)
+    var role: Role? = null
+
+    fun updateRole(role: Role) {
+        this.role = role
+    }
+
+    enum class Role(
+        val role: String,
+        val title: String
+        ){
+        GUEST("ROLE_GUEST", "게스트"),  // 인증하지 않은 직장인
+        CLIENT("ROLE_CLIENT", "사용자");
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -3,27 +3,35 @@ package site.hirecruit.hr.domain.worker.entity
 import javax.persistence.*
 
 @Entity @Table(name = "worker")
-class WorkerEntity {
+class WorkerEntity(
+    @Column(name = "github_id", nullable = false)
+    val githubId: Long?,
+
+    @Column(name = "email", nullable = false)
+    val email: String,
+
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "profile_uri", nullable = false)
+    val profileUri: String,
+
+    @Column(name = "company", nullable = false)
+    val company: String,
+
+    @Column(name = "location", nullable = false)
+    var location: String,
+
+    @Column(name = "introduction", nullable = true)
+    val introduction: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    var role: Role
+) {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     var workerId: Long? = null
-
-    var githubId: Long? = null
-
-    val email: String? = null
-
-    var name: String? = null
-
-    var profileUri: String? = null
-
-    var company: String? = null
-
-    var location: String? = null
-
-    var introduction: String? = null
-
-    @Enumerated(EnumType.STRING)
-    var role: Role? = null
 
     fun updateRole(role: Role) {
         this.role = role

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.java
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.java
@@ -5,6 +5,7 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity;
 
 import java.util.Optional;
 
+@Deprecated
 public interface WorkerRepository extends JpaRepository<WorkerEntity, Long> {
     boolean existsByGithubId(Long id);
 

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
@@ -1,0 +1,11 @@
+package site.hirecruit.hr.domain.worker.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import site.hirecruit.hr.domain.worker.entity.WorkerEntity
+
+interface WorkerRepository : JpaRepository<WorkerEntity, Long> {
+
+    fun existsByGithubId(id: Long): Boolean
+
+    fun findByGithubId(githubId: Long): WorkerEntity?
+}

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
@@ -1,8 +1,10 @@
 package site.hirecruit.hr.domain.worker.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 
+@Repository
 interface WorkerRepository : JpaRepository<WorkerEntity, Long> {
 
     fun existsByGithubId(id: Long): Boolean


### PR DESCRIPTION
## 개요 
Worker도메인 관련 코드를 모두 kotlin으로 마이그레이션했습니다.

#### 마이그레이션 목록
- `WorkerEntity`
- `WorkerRepository`

기존 Java코드는 호환성을 위해 `@Deprecated`어노테이션을 달아놓았고, 추후 Auth도메인이 kotlin으로 마이그레이션완료 된다면 삭제될 에정입니다.
intellij 에서 Duplicate class에러가 발생하지만 무시해도 됩니다.