### PR TITLE
Auth 도메인에 존재하던 Worker 의존성 제거

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
@@ -4,7 +4,8 @@ import org.springframework.context.annotation.Scope
 import org.springframework.context.annotation.ScopedProxyMode
 import org.springframework.stereotype.Component
 import org.springframework.web.context.WebApplicationContext
-import site.hirecruit.hr.domain.worker.entity.WorkerEntity
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.global.annotation.Dto
 
 /**
  * 인증/인가 시 유저의 정보를 담고 있는 객체
@@ -14,15 +15,14 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity
  * @author 정시원
  * @version 1.0
  */
+@Dto
 @Component
 @Scope(value = WebApplicationContext.SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
-open class UserAuthInfo(
+class AuthUserInfo(
     val userId: Long,
     val name: String,
     val email: String,
     val profileUri: String,
-    val role: WorkerEntity.Role
+    val role: Role
 ) {
-    constructor(workerEntity: WorkerEntity) :
-            this(workerEntity.workerId!!, workerEntity.name, workerEntity.email, workerEntity.profileUri, workerEntity.role)
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.model
+package site.hirecruit.hr.domain.auth.dto
 
 import org.springframework.context.annotation.Scope
 import org.springframework.context.annotation.ScopedProxyMode
@@ -16,7 +16,7 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity
  */
 @Component
 @Scope(value = WebApplicationContext.SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
-open class User(
+open class UserAuthInfo(
     val userId: Long,
     val name: String,
     val email: String,

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/Role.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/Role.kt
@@ -1,0 +1,9 @@
+package site.hirecruit.hr.domain.auth.entity
+
+enum class Role(
+    val role: String,
+    val title: String
+){
+    GUEST("ROLE_GUEST", "게스트"),  // 인증하지 않은 직장인
+    CLIENT("ROLE_CLIENT", "사용자");
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
@@ -19,7 +19,7 @@ class UserEntity(
     @Column(name = "profile_uri", nullable = false)
     val profileUri: String,
 
-    @Column(name = "role", nullable = false)
+    @Column(name = "role", nullable = false) @Enumerated(EnumType.STRING)
     val role: Role
 ) {
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
@@ -1,0 +1,28 @@
+package site.hirecruit.hr.domain.auth.entity
+
+import javax.persistence.*
+
+/**
+ * 회원 Entity
+ *
+ * @author 정시원
+ * @version 1.0
+ */
+@Entity @Table(name = "user")
+class UserEntity(
+    @Column(name = "github_id", nullable = false)
+    val githubId: Long,
+
+    @Column(name = "name", nullable = false)
+    val name: String,
+
+    @Column(name = "profile_uri", nullable = false)
+    val profileUri: String,
+
+    @Column(name = "role", nullable = false)
+    val role: Role
+) {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val userId: Long? = null
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
@@ -1,0 +1,8 @@
+package site.hirecruit.hr.domain.auth.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import site.hirecruit.hr.domain.auth.entity.UserEntity
+
+interface UserRepository : JpaRepository<UserEntity, Long> {
+    fun existsByGithubId(githubId: Long) : Boolean
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/CustomOAuth2UserService.kt
@@ -9,7 +9,7 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User
 import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import java.util.*
 
 private val log = KotlinLogging.logger {}
@@ -51,7 +51,7 @@ class CustomOAuth2UserService(
             oAuth2User.attributes
         )
 
-        val loginUser : User = OAuthProcessorFacade.process(oAuthAttributes)
+        val loginUser : AuthUserInfo = OAuthProcessorFacade.process(oAuthAttributes)
 
         return DefaultOAuth2User(
             Collections.singleton(SimpleGrantedAuthority(loginUser.role.role)),

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/OAuthProcessorFacade.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/OAuthProcessorFacade.kt
@@ -1,7 +1,7 @@
 package site.hirecruit.hr.domain.auth.service
 
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 
 /**
  * OAuth 인증에 관련된 로직을 실행하는 퍼사드 패턴입니다.
@@ -18,5 +18,5 @@ interface OAuthProcessorFacade {
      * @param [User] 인증에 성공한 User 객체입니다.
      * @throws OAuth2AuthenticationException 인증에 실패할 경우 발생합니다.
      */
-    fun process(oauthAttributes : OAuthAttributes) : User
+    fun process(oauthAttributes : OAuthAttributes) : AuthUserInfo
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.kt
@@ -1,7 +1,7 @@
 package site.hirecruit.hr.domain.auth.service
 
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 
 /**
  * 유저의 인증을 담당하는 서비스
@@ -14,8 +14,8 @@ interface UserAuthService {
     /**
      * 인증을 진행합니다.
      *
-     * @return [User] - 인증된 유저의 정보
+     * @return [AuthUserInfo] - 인증된 유저의 정보
      * @throws OAuth2AuthenticationException 인증에 실패할 경우 발생합니다.
      */
-    fun authentication(oAuthAttributes: OAuthAttributes): User
+    fun authentication(oAuthAttributes: OAuthAttributes): AuthUserInfo
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
@@ -1,8 +1,11 @@
-package site.hirecruit.hr.domain.auth.service
+package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.service.OAuthProcessorFacade
+import site.hirecruit.hr.domain.auth.service.UserAuthService
+import site.hirecruit.hr.domain.auth.service.UserRegistrationService
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository
 
 /**

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
@@ -2,7 +2,7 @@ package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.service.OAuthProcessorFacade
 import site.hirecruit.hr.domain.auth.service.UserAuthService
 import site.hirecruit.hr.domain.auth.service.UserRegistrationService
@@ -21,7 +21,7 @@ class OAuth2ProcessorFacadeImpl(
     private val userAuthService: UserAuthService
 ) : OAuthProcessorFacade {
 
-    override fun process(oauthAttributes: OAuthAttributes): User {
+    override fun process(oauthAttributes: OAuthAttributes): AuthUserInfo {
         // 첫 사용자라면 계정을 등록한다.
         if(workerRepository.existsByGithubId(oauthAttributes.id).not())
             userRegistrationService.registration(oauthAttributes)

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
@@ -3,10 +3,10 @@ package site.hirecruit.hr.domain.auth.service.impl
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.OAuthProcessorFacade
 import site.hirecruit.hr.domain.auth.service.UserAuthService
 import site.hirecruit.hr.domain.auth.service.UserRegistrationService
-import site.hirecruit.hr.domain.worker.repository.WorkerRepository
 
 /**
  * OAuth2 인증에 관련된 로직을 실행하는 퍼사드 패턴의 구현체입니다.
@@ -16,14 +16,14 @@ import site.hirecruit.hr.domain.worker.repository.WorkerRepository
  */
 @Service
 class OAuth2ProcessorFacadeImpl(
-    private val workerRepository: WorkerRepository,
+    private val userRepository: UserRepository,
     private val userRegistrationService: UserRegistrationService,
     private val userAuthService: UserAuthService
 ) : OAuthProcessorFacade {
 
     override fun process(oauthAttributes: OAuthAttributes): AuthUserInfo {
         // 첫 사용자라면 계정을 등록한다.
-        if(workerRepository.existsByGithubId(oauthAttributes.id).not())
+        if(userRepository.existsByGithubId(oauthAttributes.id).not())
             userRegistrationService.registration(oauthAttributes)
 
         return userAuthService.authentication(oauthAttributes)

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
@@ -2,7 +2,7 @@ package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.service.UserAuthService
 
 /**
@@ -13,7 +13,7 @@ import site.hirecruit.hr.domain.auth.service.UserAuthService
  */
 @Service
 class UserAuthServiceImpl : UserAuthService {
-    override fun authentication(oAuthAttributes: OAuthAttributes): User {
+    override fun authentication(oAuthAttributes: OAuthAttributes): AuthUserInfo {
         TODO("User authentication logic not implemented.")
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
@@ -1,8 +1,9 @@
-package site.hirecruit.hr.domain.auth.service
+package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.service.UserAuthService
 
 /**
  * 세션기반 인증을 진행하는 서비스

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -1,7 +1,8 @@
-package site.hirecruit.hr.domain.auth.service
+package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
+import site.hirecruit.hr.domain.auth.service.UserRegistrationService
 
 /**
  * @author 정시원

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -10,12 +10,6 @@ class WorkerEntity(
     @Column(name = "email", nullable = false)
     val email: String,
 
-    @Column(name = "name", nullable = false)
-    val name: String,
-
-    @Column(name = "profile_uri", nullable = false)
-    val profileUri: String,
-
     @Column(name = "company", nullable = false)
     val company: String,
 
@@ -24,24 +18,10 @@ class WorkerEntity(
 
     @Column(name = "introduction", nullable = true)
     val introduction: String? = null,
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "role", nullable = false)
-    var role: Role
 ) {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     var workerId: Long? = null
 
-    fun updateRole(role: Role) {
-        this.role = role
-    }
 
-    enum class Role(
-        val role: String,
-        val title: String
-        ){
-        GUEST("ROLE_GUEST", "게스트"),  // 인증하지 않은 직장인
-        CLIENT("ROLE_CLIENT", "사용자");
-    }
 }

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -1,5 +1,8 @@
 package site.hirecruit.hr.domain.worker.entity
 
+import org.hibernate.annotations.OnDelete
+import org.hibernate.annotations.OnDeleteAction
+import site.hirecruit.hr.domain.auth.entity.UserEntity
 import javax.persistence.*
 
 @Entity @Table(name = "worker")
@@ -18,6 +21,10 @@ class WorkerEntity(
 
     @Column(name = "introduction", nullable = true)
     val introduction: String? = null,
+
+    @OneToOne(fetch = FetchType.LAZY) @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    val user: UserEntity
 ) {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.service.impl.OAuth2ProcessorFacadeImpl
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository
 import kotlin.random.Random

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
@@ -10,8 +10,8 @@ import org.springframework.test.context.ActiveProfiles
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.impl.OAuth2ProcessorFacadeImpl
-import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository
 import kotlin.random.Random
 
@@ -42,14 +42,14 @@ internal class OAuth2ProcessorFacadeImplTest{
 
         // Given
         val oAuth2Attribute : OAuthAttributes = makeOAuth2Attribute()
-        val workerRepository : WorkerRepository = mockk()
+        val userRepository : UserRepository = mockk()
         val userRegistrationService : UserRegistrationService = mockk()
         val userAuthService : UserAuthService = mockk()
 
         val oAuth2ProcessorFacadeImpl =
-            OAuth2ProcessorFacadeImpl(workerRepository, userRegistrationService, userAuthService)
+            OAuth2ProcessorFacadeImpl(userRepository, userRegistrationService, userAuthService)
 
-        every { workerRepository.existsByGithubId(oAuth2Attribute.id) } answers { false }
+        every { userRepository.existsByGithubId(oAuth2Attribute.id) } answers { false }
         every { userRegistrationService.registration(oAuth2Attribute) } answers { Any() }
         every { userAuthService.authentication(oAuth2Attribute) } answers {
             AuthUserInfo(oAuth2Attribute.id, oAuth2Attribute.name, oAuth2Attribute.email!!, oAuth2Attribute.profileImgUri, Role.GUEST)
@@ -59,7 +59,7 @@ internal class OAuth2ProcessorFacadeImplTest{
         oAuth2ProcessorFacadeImpl.process(oAuth2Attribute)
 
         // then
-        verify(exactly = 1) { workerRepository.existsByGithubId(oAuth2Attribute.id) }
+        verify(exactly = 1) { userRepository.existsByGithubId(oAuth2Attribute.id) }
         verify(exactly = 1) { userRegistrationService.registration(oAuth2Attribute) }
         verify(exactly = 1) { userAuthService.authentication(oAuth2Attribute) }
     }

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
@@ -8,7 +8,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.ActiveProfiles
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.model.User
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.auth.service.impl.OAuth2ProcessorFacadeImpl
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository
@@ -51,7 +52,7 @@ internal class OAuth2ProcessorFacadeImplTest{
         every { workerRepository.existsByGithubId(oAuth2Attribute.id) } answers { false }
         every { userRegistrationService.registration(oAuth2Attribute) } answers { Any() }
         every { userAuthService.authentication(oAuth2Attribute) } answers {
-            User(oAuth2Attribute.id, oAuth2Attribute.name, oAuth2Attribute.email!!, oAuth2Attribute.profileImgUri, WorkerEntity.Role.GUEST)
+            AuthUserInfo(oAuth2Attribute.id, oAuth2Attribute.name, oAuth2Attribute.email!!, oAuth2Attribute.profileImgUri, Role.GUEST)
         }
 
         // when


### PR DESCRIPTION
## 개요
Auth 도메인에서 Worker 도메인에 대한 의존성을 제거하고 `AuthEntity`를 생성했습니다.

## 추가적인 변경사항
- auth/service 패키지에 있던 interface구현체들을 모두 `auth/service/impl`로 이전했습니다.
- `WorkerEntity`와 `AuthEntity`는 OneToOne 단방향 매핑으로 연관되어 있습니다.