### PR TITLE
Local Profile Test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,9 +90,11 @@ dependencies {
 
 	/** embedded redis link: https://github.com/kstyrc/embedded-redis **/
 	compileOnly 'it.ozimov:embedded-redis:0.7.2'
+	testImplementation 'it.ozimov:embedded-redis:0.7.2'
 
 	/** kotlin logger **/
 	implementation 'io.github.microutils:kotlin-logging-jvm:2.1.21'
+	testImplementation 'io.github.microutils:kotlin-logging-jvm:2.1.21'
 
 	/** to use jpa in kotlin **/
 	runtime 'org.jetbrains.kotlin:kotlin-reflect:1.6.21'

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
@@ -6,16 +6,15 @@ import io.mockk.verify
 import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.test.context.ActiveProfiles
-import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.impl.OAuth2ProcessorFacadeImpl
-import site.hirecruit.hr.domain.worker.repository.WorkerRepository
+import site.hirecruit.hr.domain.test_util.LocalTest
 import kotlin.random.Random
 
-@ActiveProfiles("local")
+@LocalTest
 internal class OAuth2ProcessorFacadeImplTest{
 
     private fun makeOAuth2Attribute() : OAuthAttributes{

--- a/src/test/java/site/hirecruit/hr/domain/mentee/service/MenteeCoreServiceTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/mentee/service/MenteeCoreServiceTest.kt
@@ -12,8 +12,10 @@ import org.springframework.boot.test.context.SpringBootTest
 import site.hirecruit.hr.domain.mentee.dto.MenteeDto
 import site.hirecruit.hr.domain.mentee.entity.MenteeEntity
 import site.hirecruit.hr.domain.mentee.repository.MenteeRepository
+import site.hirecruit.hr.domain.test_util.LocalTest
 
 @SpringBootTest
+@LocalTest
 class MenteeCoreServiceTest(
     @Autowired private var menteeRepository: MenteeRepository
 ) {

--- a/src/test/java/site/hirecruit/hr/domain/test_util/LocalTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/test_util/LocalTest.kt
@@ -1,0 +1,9 @@
+package site.hirecruit.hr.domain.test_util
+
+import org.springframework.test.context.ActiveProfiles
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@ActiveProfiles("local")
+annotation class LocalTest

--- a/src/test/java/site/hirecruit/hr/domain/test_util/LocalTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/test_util/LocalTest.kt
@@ -4,6 +4,5 @@ import org.springframework.test.context.ActiveProfiles
 
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-@MustBeDocumented
 @ActiveProfiles("local")
 annotation class LocalTest


### PR DESCRIPTION
## 개요
`local` 프로필 환경에서 테스트할 수 있도록 `@LocalTest`annotation을 만들었습니다.

- `OAuth2ProcessorFacadeImplTest`와 `MenteeCoreServiceTest`에 적용했습니다.

## Hotfix
test에서 embedded redis를 사용하지 못하던 현상을 해결했습니다.
관련 코드
```groovy
testImplementation 'it.ozimov:embedded-redis:0.7.2' 
```