### PR TITLE
회원 인증 및 세션 등록 로직 완료

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
@@ -10,20 +10,29 @@ import javax.servlet.http.HttpSession
 
 val log = KotlinLogging.logger {}
 
+/**
+ * UserAuth관련 AOP
+ *
+ * @author 정시원
+ * @since 1.0
+ */
 @Component
 @Aspect
-open class UserAuthAspect (
+private open class UserAuthAspect (
     private val httpSession: HttpSession
 ) {
 
     @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserAuthService+.authentication(..))")
-    fun userAuthService_AuthenticationMethodPointCut(){}
+    private fun userAuthService_AuthenticationMethodPointCut(){}
 
+    /**
+     * [site.hirecruit.hr.domain.auth.service.UserAuthService.authentication]에서의 유저 인증 수행 후 세션을 발급하는 AOP method
+     */
     @AfterReturning(
         "userAuthService_AuthenticationMethodPointCut()",
         returning = "authUserInfo"
     )
-    fun setSessionByAuthUserInfo(authUserInfo: AuthUserInfo): Any{
+    private fun setSessionByAuthUserInfo(authUserInfo: AuthUserInfo): Any{
         log.debug("UserAuthAspect.setSessionByAuthUserInfo active")
         httpSession.setAttribute("authUserInfo", authUserInfo)
         log.debug("session id='${httpSession.id}', authUserInfo='${httpSession.getAttribute("authUserInfo")}'")

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
@@ -1,0 +1,33 @@
+package site.hirecruit.hr.domain.auth.aop
+
+import mu.KotlinLogging
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import javax.servlet.http.HttpSession
+
+val log = KotlinLogging.logger {}
+
+@Component
+@Aspect
+open class UserAuthAspect (
+    private val httpSession: HttpSession
+) {
+
+    @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserAuthService+.authentication(..))")
+    fun userAuthService_AuthenticationMethodPointCut(){}
+
+    @AfterReturning(
+        "userAuthService_AuthenticationMethodPointCut()",
+        returning = "authUserInfo"
+    )
+    fun setSessionByAuthUserInfo(authUserInfo: AuthUserInfo): Any{
+        log.debug("UserAuthAspect.setSessionByAuthUserInfo active")
+        httpSession.setAttribute("authUserInfo", authUserInfo)
+        log.debug("session id='${httpSession.id}', authUserInfo='${httpSession.getAttribute("authUserInfo")}'")
+        return authUserInfo
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
@@ -23,4 +23,8 @@ open class AuthUserInfo(
     val email: String?,
     val profileUri: String,
     val role: Role
-)
+): java.io.Serializable {
+    override fun toString(): String {
+        return "AuthUserInfo(githubId=$githubId, name='$name', email=$email, profileUri='$profileUri', role=$role)"
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.ScopedProxyMode
 import org.springframework.stereotype.Component
 import org.springframework.web.context.WebApplicationContext
 import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.global.annotation.Dto
 
 /**
  * 인증/인가 시 유저의 정보를 담고 있는 객체
@@ -21,10 +20,10 @@ open class AuthUserInfo(
     val githubId: Long,
     val name: String,
     val email: String?,
-    val profileUri: String,
+    val profileImgUri: String,
     val role: Role
 ): java.io.Serializable {
     override fun toString(): String {
-        return "AuthUserInfo(githubId=$githubId, name='$name', email=$email, profileUri='$profileUri', role=$role)"
+        return "AuthUserInfo(githubId=$githubId, name='$name', email=$email, profileUri='$profileImgUri', role=$role)"
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
@@ -19,7 +19,7 @@ class TempUserEntity(
     val name: String,
 
     @Column(name = "profile_uri")
-    val profileUri: String,
+    val profileImgUri: String,
 ) {
 
     @javax.persistence.Transient

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
@@ -23,7 +23,8 @@ class TempUserEntity(
 ) {
 
     @javax.persistence.Transient
-    val role = Role.GUEST // 임시 유저의 권한은 GUEST이다.
+    var role = Role.GUEST // 임시 유저의 권한은 GUEST이다.
+        private set
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is TempUserEntity) return false

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepository.kt
@@ -1,0 +1,11 @@
+package site.hirecruit.hr.domain.auth.repository
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+
+interface UserCustomRepository {
+
+    /**
+     * github_id로 UserEntity의 정보와 Worker.email를 가져옵니다.
+     */
+    fun findUserAndWorkerEmailByGithubId(githubId: Long): AuthUserInfo?
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepository.kt
@@ -2,6 +2,12 @@ package site.hirecruit.hr.domain.auth.repository
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 
+/**
+ * UserEntity의 CustomRepository입니다.
+ *
+ * @author 정시원
+ * @since 1.0
+ */
 interface UserCustomRepository {
 
     /**

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImpl.kt
@@ -1,9 +1,17 @@
 package site.hirecruit.hr.domain.auth.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 
-class UserCustomRepositoryImpl(
+/**
+ * UserCustomRepository의 구현체 입니다.
+ *
+ * @since 1.0
+ * @author 정시원
+ */
+@Repository
+open class UserCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ): UserCustomRepository {
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package site.hirecruit.hr.domain.auth.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+
+class UserCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+): UserCustomRepository {
+
+    override fun findUserAndWorkerEmailByGithubId(githubId: Long): AuthUserInfo {
+        TODO("queryDSL feature 추가되면 작성할예정")
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
@@ -3,6 +3,6 @@ package site.hirecruit.hr.domain.auth.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import site.hirecruit.hr.domain.auth.entity.UserEntity
 
-interface UserRepository : JpaRepository<UserEntity, Long> {
+interface UserRepository : JpaRepository<UserEntity, Long>, UserCustomRepository {
     fun existsByGithubId(githubId: Long) : Boolean
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserAuthService.kt
@@ -7,7 +7,7 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
  * 유저의 인증을 담당하는 서비스
  *
  * @author 정시원
- * @version 1.0
+ * @since 1.0
  */
 interface UserAuthService {
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/TempUserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/TempUserRegistrationServiceImpl.kt
@@ -23,7 +23,7 @@ class TempUserRegistrationServiceImpl(
         val tempUserEntity = TempUserEntity(
             githubId = oAuthAttributes.id,
             name = oAuthAttributes.name,
-            profileUri = oAuthAttributes.profileImgUri
+            profileImgUri = oAuthAttributes.profileImgUri
         )
         tempUserRepository.save(tempUserEntity)
     }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
@@ -3,21 +3,20 @@ package site.hirecruit.hr.domain.auth.service.impl
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.stereotype.Service
-import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserAuthService
 
 /**
- * 세션기반 인증을 진행하는 서비스
+ * OAuth2 client의 정보를 기반으로 인증하는 서비스
  *
  * @author 정시원
- * @version 1.0
+ * @since 1.0
  */
 @Service
-class UserAuthServiceImpl(
+open class UserAuthServiceImpl(
     private val userRepository: UserRepository,
     private val tempUserRepository: TempUserRepository
 ) : UserAuthService {

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
@@ -23,17 +23,17 @@ open class UserAuthServiceImpl(
 
     override fun authentication(oAuthAttributes: OAuthAttributes): AuthUserInfo {
         return if (tempUserRepository.existsById(oAuthAttributes.id))
-            createAuthInfoWithTempUserEntity(oAuthAttributes)
+            createAuthUserInfoWithTempUserEntity(oAuthAttributes)
         else
-            createAuthInfoWithUserEntity(oAuthAttributes)
+            createAuthUserInfoWithUserEntity(oAuthAttributes)
     }
 
-    private fun createAuthInfoWithUserEntity(oAuthAttributes: OAuthAttributes): AuthUserInfo {
+    private fun createAuthUserInfoWithUserEntity(oAuthAttributes: OAuthAttributes): AuthUserInfo {
         return userRepository.findUserAndWorkerEmailByGithubId(oAuthAttributes.id)
             ?: throw OAuth2AuthenticationException("해당 oauth정보로 회원을 찾을 수 없습니다. [githubId = '${oAuthAttributes.id}']")
     }
 
-    private fun createAuthInfoWithTempUserEntity(oAuthAttributes: OAuthAttributes): AuthUserInfo{
+    private fun createAuthUserInfoWithTempUserEntity(oAuthAttributes: OAuthAttributes): AuthUserInfo{
         val tempUserEntity = tempUserRepository.findByIdOrNull(oAuthAttributes.id)
             ?: throw OAuth2AuthenticationException("임시 회원의 유효기간이 만료되었거나, 잘못된 회원 정보입니다.")
         return AuthUserInfo(

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
@@ -41,7 +41,7 @@ open class UserAuthServiceImpl(
             name = tempUserEntity.name,
             email = null,
             role = tempUserEntity.role,
-            profileUri = tempUserEntity.profileImgUri
+            profileImgUri = tempUserEntity.profileImgUri
         )
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImpl.kt
@@ -41,7 +41,7 @@ open class UserAuthServiceImpl(
             name = tempUserEntity.name,
             email = null,
             role = tempUserEntity.role,
-            profileUri = tempUserEntity.profileUri
+            profileUri = tempUserEntity.profileImgUri
         )
     }
 }

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/TempUserRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/TempUserRegistrationServiceImplTest.kt
@@ -4,12 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import net.bytebuddy.utility.RandomString
-import org.assertj.core.api.BDDAssertions.then
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.Mock
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.entity.TempUserEntity
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
@@ -43,7 +39,7 @@ internal class TempUserRegistrationServiceImplTest(){
         val tempUserEntity = TempUserEntity(
             githubId = oAuth2Attribute.id,
             name = oAuth2Attribute.name,
-            profileUri = oAuth2Attribute.profileImgUri
+            profileImgUri = oAuth2Attribute.profileImgUri
         )
         every { tempUserRepository.existsById(oAuth2Attribute.id) } answers { false }
         every { tempUserRepository.save(tempUserEntity) } answers {tempUserEntity}

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserAuthServiceImplTest.kt
@@ -1,0 +1,133 @@
+package site.hirecruit.hr.domain.auth.service.impl
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import net.bytebuddy.utility.RandomString
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.entity.TempUserEntity
+import site.hirecruit.hr.domain.auth.repository.TempUserRepository
+import site.hirecruit.hr.domain.auth.repository.UserRepository
+import kotlin.random.Random
+
+internal class UserAuthServiceImplTest{
+
+    private fun makeOAuth2Attributes() : OAuthAttributes {
+        val attributes = mapOf<String, Any>(
+            "id" to Random.nextInt(8),
+            "name" to RandomString.make(8),
+            "email" to "${RandomString.make(10)}${RandomString.make(6)}.${RandomString.make(3)}}",
+            "avatar_url" to RandomString.make()
+        )
+        return OAuthAttributes.of(
+            registrationId = "github",
+            userNameAttributeName = "id",
+            attributes = attributes
+        )
+    }
+
+    private val tempUserRepository: TempUserRepository = mockk()
+
+    @DisplayName("TempUser(임시유저)가 ")
+    @Nested
+    inner class TempUserAuthTest{
+
+        private val userRepository: UserRepository = spyk()
+
+        @Test @DisplayName("인증을 받는다면?")
+        fun `TempUser가 인증을 받는다면`(){
+            // Given
+            val oAuth2Attributes = makeOAuth2Attributes()
+
+            val userAuthServiceImpl = UserAuthServiceImpl(userRepository, tempUserRepository)
+
+            every { tempUserRepository.existsById(oAuth2Attributes.id) } answers {true} // 임시회원이 존재한다면
+            every { tempUserRepository.findByIdOrNull(oAuth2Attributes.id) } answers {
+                TempUserEntity(
+                    githubId = oAuth2Attributes.id,
+                    name = oAuth2Attributes.name,
+                    profileImgUri = oAuth2Attributes.profileImgUri
+                )
+            }
+
+            // when
+            val userAuthInfo = userAuthServiceImpl.authentication(oAuth2Attributes)
+
+            // then
+            verify(exactly = 1) {tempUserRepository.findByIdOrNull(oAuth2Attributes.id)}
+            assertEquals(userAuthInfo.githubId, oAuth2Attributes.id)
+            assertEquals(userAuthInfo.name, oAuth2Attributes.name)
+            assertEquals(userAuthInfo.profileImgUri, oAuth2Attributes.profileImgUri)
+            assertEquals(userAuthInfo.role, Role.GUEST)
+        }
+
+        @Test @DisplayName("인증을 받을 떄 인증정보가 조회되지 않는다면?")
+        fun `인증을 받을 떄 정보를 가져올 수 없다면`(){
+            // Given
+            val oAuth2Attributes = makeOAuth2Attributes()
+            val userAuthServiceImpl = UserAuthServiceImpl(userRepository, tempUserRepository)
+
+            every { tempUserRepository.existsById(oAuth2Attributes.id) } answers {true} // 임시회원이 존재한다면
+            every { tempUserRepository.findByIdOrNull(oAuth2Attributes.id) } answers { null }
+
+            // when then
+            assertThrows<OAuth2AuthenticationException> ("임시 회원의 유효기간이 만료되었거나, 잘못된 회원 정보입니다."){
+                userAuthServiceImpl.authentication(oAuth2Attributes)
+            }
+        }
+    }
+
+    @DisplayName("User(회원)가 ")
+    @Nested
+    inner class UserAuthTest{
+        private val userRepository: UserRepository = mockk()
+
+        @Test @DisplayName("인증을 받는다면?")
+        fun `User가 인증을 받는다면`(){
+            // Given
+            val oAuth2Attributes = makeOAuth2Attributes()
+
+            val userAuthServiceImpl = UserAuthServiceImpl(userRepository, tempUserRepository)
+            val authUserInfo = AuthUserInfo(
+                githubId = oAuth2Attributes.id,
+                name = oAuth2Attributes.name,
+                email = "${RandomString.make(8)}@${RandomString.make(5)}.${RandomString.make(3)}",
+                profileImgUri = oAuth2Attributes.profileImgUri,
+                Role.CLIENT
+            )
+
+            every { tempUserRepository.existsById(oAuth2Attributes.id) } answers {false} // 임시회원이 존재한다면
+            every { userRepository.findUserAndWorkerEmailByGithubId(oAuth2Attributes.id) } answers { authUserInfo }
+
+            // when
+            val authenticatedUserAuthInfo = userAuthServiceImpl.authentication(oAuth2Attributes)
+
+            // then
+            verify(exactly = 1) {userRepository.findUserAndWorkerEmailByGithubId(oAuth2Attributes.id)}
+            assertEquals(authUserInfo, authenticatedUserAuthInfo)
+        }
+
+        @Test @DisplayName("인증을 받을 떄 인증정보가 조회되지 않는다면?")
+        fun `User가 인증을 받을 떄 정보를 가져올 수 없다면`(){
+            // Given
+            val oAuth2Attributes = makeOAuth2Attributes()
+            val userAuthServiceImpl = UserAuthServiceImpl(userRepository, tempUserRepository)
+
+            every { tempUserRepository.existsById(oAuth2Attributes.id) } answers {false} // 임시회원이 아니라면
+            every { userRepository.findUserAndWorkerEmailByGithubId(oAuth2Attributes.id) } answers { null }
+
+            // when then
+            assertThrows<OAuth2AuthenticationException> ("해당 oauth정보로 회원을 찾을 수 없습니다. [githubId = '${oAuth2Attributes.id}']"){
+                userAuthServiceImpl.authentication(oAuth2Attributes)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## 개요
제목과 같습니다.

## 로직 설명
- 인증을 시도하는 회원이 TempUser(임시회원)이라면 `TempUserEntity`를 기반으로 인증을 시도합니다.
- 인증을 시도하는 회원이 User(회원)이라면 `UserEntity`를 기반으로 인증을 시도합니다.

회원의 인증을 수행하는 로직(`UserAuthService.authentication()`)이 순수한 비즈니스 로직만 남기기위해 [`UserAuthAspect.setSessionByAuthUserInfo`](https://github.com/themoment-team/HiRecruit-server/compare/develop...feature/userAuth-logic?expand=1#diff-34b82ea6f657e2633a01b49161eec958c8752ed7b3b1f337d0a8789e105d8d5eR28-R40)에서  `UserAuthService.authentication()`의 반환값인 `UserAuthInfo`를 session
에 등록하는 AOP를 만들었습니다. 

## 기타 변경사항
- auth도메인의 dto들의 `profileUri`필드를 `profileImgUri`로 변경

### TODO
아직 querydsl config를 완료하지 않아 custom repository만들고 구현하지 않았습니다.

### 테스트 커버리지

![CleanShot 2022-05-16 at 09 12 00](https://user-images.githubusercontent.com/62932968/168500572-7074aeba-3a50-47f2-9295-8d171b175b6f.png)

