### PR TITLE
embedded redis의 기본 포트가 실행중일 때 다른 포트로 실행하는 로직 추가

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
@@ -20,24 +20,25 @@ private val log = KotlinLogging.logger {}
 @Configuration
 @Profile("local")
 class EmbeddedRedisConfig(
-    @Value("\${spring.redis.port}") val redisPort: Int
+    @Value("\${spring.redis.port}") private val redisPort: Int
 ) {
     init {
         log.info("embedded redis will start port = '{}'", redisPort)
     }
 
-    lateinit var redisServer: RedisServer
+    private lateinit var redisServer: RedisServer
 
     @PostConstruct
-    fun redisServer() {
+    private fun redisServer() {
         redisServer = RedisServer(redisPort)
         redisServer.start()
         log.info("embedded redis started successfully")
     }
 
     @PreDestroy
-    fun stopRedis() {
+    private fun stopRedis() {
         redisServer.stop()
         log.info("embedded redis stopped successfully")
     }
+
 }

--- a/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/config/EmbeddedRedisConfig.kt
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import redis.embedded.RedisServer
+import java.io.BufferedReader
+import java.io.InputStreamReader
 import javax.annotation.PostConstruct
 import javax.annotation.PreDestroy
 
@@ -20,17 +22,16 @@ private val log = KotlinLogging.logger {}
 @Configuration
 @Profile("local")
 class EmbeddedRedisConfig(
-    @Value("\${spring.redis.port}") private val redisPort: Int
+    @Value("\${spring.redis.port}") private val defaultRedisPort: Int
 ) {
-    init {
-        log.info("embedded redis will start port = '{}'", redisPort)
-    }
 
     private lateinit var redisServer: RedisServer
 
     @PostConstruct
     private fun redisServer() {
-        redisServer = RedisServer(redisPort)
+        val port: Int = if (isRedisRunning()) findAvailablePort() else defaultRedisPort
+        log.info("embedded redis will start port = '{}'", defaultRedisPort)
+        redisServer = RedisServer(port)
         redisServer.start()
         log.info("embedded redis started successfully")
     }
@@ -39,6 +40,49 @@ class EmbeddedRedisConfig(
     private fun stopRedis() {
         redisServer.stop()
         log.info("embedded redis stopped successfully")
+    }
+
+    /**
+     * Embedded Redis가 현재 실행중인지 확인
+     */
+    private fun isRedisRunning(): Boolean {
+        return isRunning(executeGrepProcessCommand(defaultRedisPort))
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 조회
+     */
+    private fun findAvailablePort(): Int {
+        for (port in 10000..65535) {
+            val process = executeGrepProcessCommand(port)
+            if (!isRunning(process)) {
+                return port
+            }
+        }
+        throw IllegalStateException("Not Found Available port: 10000 ~ 65535")
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private fun executeGrepProcessCommand(port: Int): Process {
+        val command = "netstat -nat | grep LISTEN|grep $port"
+        val shell = arrayOf("/bin/sh", "-c", command)
+        return Runtime.getRuntime().exec(shell)
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private fun isRunning(process: Process): Boolean {
+        var line: String?
+        val pidInfo = StringBuilder()
+        BufferedReader(InputStreamReader(process.inputStream)).use { input ->
+            while (input.readLine().also { line = it } != null) {
+                pidInfo.append(line)
+            }
+        }
+        return pidInfo.isNotEmpty()
     }
 
 }


### PR DESCRIPTION
## 개요
embedded redis의 기본 포트가 실행중일 때 다른 포트로 실행하는 로직을 추가했습니다.

local에 redis 기본포트에 이미 어떤 프로세스가 사용하고 있을 때 서버를 실행하지 못하여 해당 기능을 추가했습니다.