### PR TITLE
UserCustomRepositoryImpl 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ allOpen {
     annotation("javax.persistence.MappedSuperclass")
     annotation("javax.persistence.Embeddable")
     annotation("org.springframework.context.annotation.Configuration")
+    annotation("org.springframework.stereotype.Repository")
 }
 
 noArg {
@@ -61,6 +62,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.github.microutils:kotlin-logging-jvm:2.1.21")
+    testImplementation("io.github.microutils:kotlin-logging-jvm:2.1.21")
     implementation("io.springfox:springfox-boot-starter:3.0.0")
 
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
@@ -1,5 +1,6 @@
 package site.hirecruit.hr.domain.auth.dto
 
+import com.querydsl.core.annotations.QueryProjection
 import org.springframework.context.annotation.Scope
 import org.springframework.context.annotation.ScopedProxyMode
 import org.springframework.stereotype.Component
@@ -16,7 +17,7 @@ import site.hirecruit.hr.domain.auth.entity.Role
  */
 @Component
 @Scope(value = WebApplicationContext.SCOPE_SESSION, proxyMode = ScopedProxyMode.TARGET_CLASS)
-open class AuthUserInfo(
+open class AuthUserInfo @QueryProjection constructor(
     val githubId: Long,
     val name: String,
     val email: String?,

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
@@ -13,11 +13,14 @@ class UserEntity(
     @Column(name = "github_id", nullable = false)
     val githubId: Long,
 
+    @Column(name = "email", nullable = false)
+    val email: String,
+
     @Column(name = "name", nullable = false)
     val name: String,
 
     @Column(name = "profile_uri", nullable = false)
-    val profileUri: String,
+    val profileImgUri: String,
 
     @Column(name = "role", nullable = false) @Enumerated(EnumType.STRING)
     val role: Role

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImpl.kt
@@ -1,8 +1,11 @@
 package site.hirecruit.hr.domain.auth.repository
 
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.QAuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.QUserEntity.userEntity
 
 /**
  * UserCustomRepository의 구현체 입니다.
@@ -11,11 +14,21 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
  * @author 정시원
  */
 @Repository
-open class UserCustomRepositoryImpl(
+class UserCustomRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ): UserCustomRepository {
 
-    override fun findUserAndWorkerEmailByGithubId(githubId: Long): AuthUserInfo {
-        TODO("queryDSL feature 추가되면 작성할예정")
+    override fun findUserAndWorkerEmailByGithubId(githubId: Long): AuthUserInfo? {
+        return queryFactory
+            .select(QAuthUserInfo(
+                Expressions.constantAs(githubId, userEntity.githubId),
+                userEntity.name,
+                userEntity.email,
+                userEntity.profileImgUri,
+                userEntity.role
+            ))
+            .from(userEntity)
+            .where(userEntity.githubId.eq(githubId))
+            .fetchOne()
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -7,12 +7,6 @@ import javax.persistence.*
 
 @Entity @Table(name = "worker")
 class WorkerEntity(
-    @Column(name = "github_id", nullable = false)
-    val githubId: Long?,
-
-    @Column(name = "email", nullable = false)
-    val email: String,
-
     @Column(name = "company", nullable = false)
     val company: String,
 

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
@@ -6,8 +6,4 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 
 @Repository
 interface WorkerRepository : JpaRepository<WorkerEntity, Long> {
-
-    fun existsByGithubId(id: Long): Boolean
-
-    fun findByGithubId(githubId: Long): WorkerEntity?
 }

--- a/src/test/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImplTest.kt
@@ -1,0 +1,61 @@
+package site.hirecruit.hr.domain.auth.repository
+
+import mu.KotlinLogging
+import net.bytebuddy.utility.RandomString
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.function.Executable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.test_util.LocalTest
+import site.hirecruit.hr.domain.worker.repository.WorkerRepository
+import site.hirecruit.hr.global.config.QuerydslConfig
+import kotlin.random.Random
+
+val log = KotlinLogging.logger{}
+
+@LocalTest
+@DataJpaTest
+@Import(QuerydslConfig::class)
+internal class UserCustomRepositoryImplTest{
+
+    @Autowired lateinit var userRepository: UserRepository
+
+    @Autowired lateinit var workerRepository: WorkerRepository
+
+    fun createUserEntity(): UserEntity{
+        return userRepository.save(
+            UserEntity(
+                githubId = Random.nextLong(),
+                email = "${RandomString.make(7)}@${RandomString.make(5)}.${RandomString.make(3)}",
+                name = RandomString.make(3),
+                profileImgUri = RandomString.make(),
+                Role.CLIENT
+            )
+        )
+    }
+
+    @Test @DisplayName("findUserAndWorkerEmailByGithubId 테스트")
+    fun findUserAndWorkerEntityByGithubIdTest(){
+        // given
+        val userEntity = createUserEntity()
+
+        // when
+        val authUserInfo = userRepository.findUserAndWorkerEmailByGithubId(userEntity.githubId)!!
+        log.info("result='$authUserInfo'")
+
+        // then
+        assertAll(
+            Executable { assertEquals(userEntity.githubId, authUserInfo.githubId) },
+            Executable { assertEquals(userEntity.email, authUserInfo.email) },
+            Executable { assertEquals(userEntity.name, authUserInfo.name) },
+            Executable { assertEquals(userEntity.profileImgUri, authUserInfo.profileImgUri) },
+            Executable { assertEquals(userEntity.role, authUserInfo.role) }
+        )
+    }
+}

--- a/src/test/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/repository/UserCustomRepositoryImplTest.kt
@@ -2,8 +2,8 @@ package site.hirecruit.hr.domain.auth.repository
 
 import mu.KotlinLogging
 import net.bytebuddy.utility.RandomString
-import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.function.Executable


### PR DESCRIPTION
## 개요 
querydsl 설정이 완료되어 `WorkerRepositoryImpl`를 구현하게 되었습니다. 
구현 중 user, worker Entity가 부분 수정 되었습니다.

<img width=350 src="https://user-images.githubusercontent.com/62932968/168721924-e618ee04-1753-480a-a8cb-d5f5c7bd97bd.png">
<img width="562" alt="CleanShot 2022-05-17 at 12 22 38@2x" src="https://user-images.githubusercontent.com/62932968/168721975-6605edef-abbb-47cc-a587-92b07524313f.png">

### 기타 변경사항
- `@Repository`어노테이션을 사용할 떄 해당 클래스는 open됩니다.
   > DataJPA의 Custom Repository를 사용하려면 해당 구현 클래스를 open해야 합니다.
- 필드명 변경
   - profileUri -> profileImgUri