### PR TITLE
Session에 있는 user정보를 가져오는 annotation 생성

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/annotation/CurrentAuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/annotation/CurrentAuthUserInfo.kt
@@ -1,0 +1,13 @@
+package site.hirecruit.hr.domain.auth.annotation
+
+/**
+ * 해당 annotation을 통해 현제 세션에 존재하고 있는 사용자의 정보([site.hirecruit.hr.domain.auth.dto.AuthUserInfo])를 contoller에서 가져올 수 있습니다.
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CurrentAuthUserInfo(){
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
@@ -6,6 +6,7 @@ import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Pointcut
 import org.springframework.stereotype.Component
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.global.data.SessionAttribute
 import javax.servlet.http.HttpSession
 
 val log = KotlinLogging.logger {}
@@ -34,8 +35,8 @@ private open class UserAuthAspect (
     )
     private fun setSessionByAuthUserInfo(authUserInfo: AuthUserInfo): Any{
         log.debug("UserAuthAspect.setSessionByAuthUserInfo active")
-        httpSession.setAttribute("authUserInfo", authUserInfo)
-        log.debug("session id='${httpSession.id}', authUserInfo='${httpSession.getAttribute("authUserInfo")}'")
+        httpSession.setAttribute(SessionAttribute.AUTH_USER_INFO.attributeName, authUserInfo)
+        log.debug("session id='${httpSession.id}', authUserInfo='${httpSession.getAttribute(SessionAttribute.AUTH_USER_INFO.attributeName)}'")
         return authUserInfo
     }
 

--- a/src/main/java/site/hirecruit/hr/global/annotation/CurrentAuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/global/annotation/CurrentAuthUserInfo.kt
@@ -3,11 +3,18 @@ package site.hirecruit.hr.global.annotation
 /**
  * 해당 annotation을 통해 현제 세션에 존재하고 있는 사용자의 정보([site.hirecruit.hr.domain.auth.dto.AuthUserInfo])를 contoller에서 가져올 수 있습니다.
  *
+ * ## code example
+ * ```kotlin
+ * @GetMapping("/example")
+ * fun example(@CurrentAuthUserInfo authUserInfo: AuthUserInfo) {
+ *      ...
+ * }
+ * ```
+ *
  * @author 정시원
  * @since 1.0
+ * @see site.hirecruit.hr.global.resolver.CurrentAuthUserInfoResolver
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class CurrentAuthUserInfo(){
-
-}
+annotation class CurrentAuthUserInfo

--- a/src/main/java/site/hirecruit/hr/global/annotation/CurrentAuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/global/annotation/CurrentAuthUserInfo.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.annotation
+package site.hirecruit.hr.global.annotation
 
 /**
  * 해당 annotation을 통해 현제 세션에 존재하고 있는 사용자의 정보([site.hirecruit.hr.domain.auth.dto.AuthUserInfo])를 contoller에서 가져올 수 있습니다.

--- a/src/main/java/site/hirecruit/hr/global/config/WebConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/config/WebConfig.kt
@@ -1,0 +1,17 @@
+package site.hirecruit.hr.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import site.hirecruit.hr.global.resolver.CurrentAuthUserInfoResolver
+
+
+@Configuration
+class WebConfig(
+    private val currentAuthUserInfoResolver: CurrentAuthUserInfoResolver
+): WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(currentAuthUserInfoResolver)
+    }
+}

--- a/src/main/java/site/hirecruit/hr/global/data/SessionAttribute.kt
+++ b/src/main/java/site/hirecruit/hr/global/data/SessionAttribute.kt
@@ -1,0 +1,7 @@
+package site.hirecruit.hr.global.data
+
+enum class SessionAttribute(
+    val attributeName: String
+) {
+    AUTH_USER_INFO("authUserInfo")
+}

--- a/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
+++ b/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
@@ -12,6 +12,8 @@ import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import javax.servlet.http.HttpSession
 
 /**
+ * [CurrentAuthUserInfo] annotation을 통해 controller에서 Session정보를 가져오는 [HandlerMethodArgumentResolver]
+ *
  * @author 정시원
  * @since 1.0
  */
@@ -29,7 +31,7 @@ class CurrentAuthUserInfoResolver(
         mavContainer: ModelAndViewContainer?,
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
-    ): Any? {
+    ): Any {
         return httpSession.getAttribute("authUserInfo")
             ?: throw HttpClientErrorException(HttpStatus.UNAUTHORIZED)
     }

--- a/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
+++ b/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
@@ -9,6 +9,7 @@ import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
+import site.hirecruit.hr.global.data.SessionAttribute
 import javax.servlet.http.HttpSession
 
 /**
@@ -32,7 +33,7 @@ class CurrentAuthUserInfoResolver(
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?
     ): Any {
-        return httpSession.getAttribute("authUserInfo")
+        return httpSession.getAttribute(SessionAttribute.AUTH_USER_INFO.attributeName)
             ?: throw HttpClientErrorException(HttpStatus.UNAUTHORIZED)
     }
 

--- a/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
+++ b/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
@@ -1,0 +1,38 @@
+package site.hirecruit.hr.global.resolver
+
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+import site.hirecruit.hr.domain.auth.annotation.CurrentAuthUserInfo
+import javax.servlet.http.HttpSession
+
+/**
+ * @author 정시원
+ * @since 1.0
+ */
+@Component
+class CurrentAuthUserInfoResolver(
+    private val httpSession: HttpSession
+): HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(CurrentAuthUserInfo::class.java);
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?
+    ): Any? {
+        return httpSession.getAttribute("authUserInfo")
+            ?: throw HttpClientErrorException(HttpStatus.UNAUTHORIZED)
+    }
+
+
+}

--- a/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
+++ b/src/main/java/site/hirecruit/hr/global/resolver/CurrentAuthUserInfoResolver.kt
@@ -8,7 +8,7 @@ import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
-import site.hirecruit.hr.domain.auth.annotation.CurrentAuthUserInfo
+import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import javax.servlet.http.HttpSession
 
 /**


### PR DESCRIPTION
## 개요
세션에 인증한 유저를 저장한 `AuthUserInfo`객체를 controller에서 `@CurrentAuthUserInfo`를 통해 불러올 수 있도록 하는 `HandlerMethodArgumentResolver`구현 및 등록

### example
```kotlin
@GetMapping("/example")
fun example(@CurrentAuthUserInfo authUserInfo: AuthUserInfo) {
     ...
}
```

### 기타 수정사항
- HttpSession에 저장된 유저정보의 attribute name을 enum으로 관리합니다.