### PR TITLE
Feature/aws sns [create topic 피쳐 개발]

### DIFF
--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
@@ -26,7 +26,7 @@ class CredentialService(private val awsSnsConfig: AwsSnsConfig) {
         return SnsClient.builder()
             .credentialsProvider(
                 getAwsCredentials(awsSnsConfig.awsAccessKey, awsSnsConfig.awsSecretKey)
-            ).region(Region.AP_NORTHEAST_2)
+            ).region(Region.of(awsSnsConfig.awsRegion))
             .build()
     }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
@@ -26,7 +26,7 @@ class CredentialService(private val awsSnsConfig: AwsSnsConfig) {
         return SnsClient.builder()
             .credentialsProvider(
                 getAwsCredentials(awsSnsConfig.awsAccessKey, awsSnsConfig.awsSecretKey)
-            ).region(Region.of(awsSnsConfig.awsRegion))
+            ).region(Region.AP_NORTHEAST_2)
             .build()
     }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
@@ -16,17 +16,28 @@ import software.amazon.awssdk.services.sns.SnsClient
 @Service
 class CredentialService(private val awsSnsConfig: AwsSnsConfig) {
 
-    fun getAwsCredentials(accessKey: String, secretKey: String): AwsCredentialsProvider {
-        return AwsCredentialsProvider {
-            AwsBasicCredentials.create(accessKey, secretKey)
-        }
-    }
-
+    /**
+     * aws sns 서비스의 permission이 있는 IAM의 자격을 얻어 properties에 알맞는 region으로 SnsClient를 제공해준다.
+     *
+     * @see AwsSnsConfig sns전용 IAM에 대한 설정
+     */
     fun getSnsClient(): SnsClient {
+
         return SnsClient.builder()
             .credentialsProvider(
                 getAwsCredentials(awsSnsConfig.awsAccessKey, awsSnsConfig.awsSecretKey)
             ).region(Region.of(awsSnsConfig.awsRegion))
             .build()
+    }
+
+    /**
+     * accessKey, secretKey 로 해당 IAM 의 자격을 얻는다.
+     *
+     * @see getSnsClient - credentials가 필요한 부분에 넣어준다.
+     */
+    private fun getAwsCredentials(accessKey: String, secretKey: String): AwsCredentialsProvider {
+        return AwsCredentialsProvider {
+            AwsBasicCredentials.create(accessKey, secretKey)
+        }
     }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/controller/SnsController.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/controller/SnsController.kt
@@ -1,0 +1,13 @@
+package site.hirecruit.hr.thirdParty.aws.sns.controller
+
+import org.springframework.web.bind.annotation.RestController
+import site.hirecruit.hr.thirdParty.aws.config.AwsSnsConfig
+import site.hirecruit.hr.thirdParty.aws.service.CredentialService
+
+@RestController
+class SnsController(
+    private val awsSnsConfig: AwsSnsConfig,
+    private val credentialService: CredentialService
+) {
+
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
@@ -1,11 +1,5 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
-import org.springframework.stereotype.Service
-
-@Service
-class SnsTopicFactoryService {
-
-    fun createTopic(topicName: String){
-
-    }
+interface SnsTopicFactoryService {
+    fun createTopic(topicName: String)
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
@@ -1,0 +1,11 @@
+package site.hirecruit.hr.thirdParty.aws.sns.service
+
+import org.springframework.stereotype.Service
+
+@Service
+class SnsTopicFactoryService {
+
+    fun createTopic(topicName: String){
+
+    }
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -20,18 +20,17 @@ class SnsTopicFactoryServiceImpl(
     /**
      * aws sns topic을 생성해주는 서비스
      *
-     * @see CreateTopicRequest.name - Constraints
+     * @see CreateTopicRequest.name - Constraints: topicName must be ASCII 0 ~ 256
+     * @see SnsTopicSubSystemFacade.servingTopicRequestToSnsClient - aws-api가 직접적으로 로직을 처리 함
      */
     override fun createTopic(topicName: String) {
 
         // topicRequest 생성
         val topicRequest = snsTopicSubSystemFacade.createTopicRequest(topicName)
 
-        // topic 생성
-        val createTopic = credentialService.getSnsClient().createTopic(topicRequest)
+        // topicRequest를 aws-sns-api가 처리하도록 serving 함.
+        snsTopicSubSystemFacade.servingTopicRequestToSnsClient(topicRequest, credentialService.getSnsClient())
 
-        // topic이 성공적으로 생성됐는지 assertion
-        snsTopicSubSystemFacade.sdkHealthChecker(createTopic)
     }
 
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -1,8 +1,8 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
 import org.springframework.stereotype.Service
+import site.hirecruit.hr.thirdParty.aws.service.CredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsTopicSubSystemFacade
-import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
 
 /**
@@ -12,7 +12,10 @@ import software.amazon.awssdk.services.sns.model.CreateTopicRequest
  * @since 1.0.0
  */
 @Service
-class SnsTopicFactoryServiceImpl(val snsTopicSubSystemFacade: SnsTopicSubSystemFacade) : SnsTopicFactoryService{
+class SnsTopicFactoryServiceImpl(
+    private val credentialService: CredentialService,
+    private val snsTopicSubSystemFacade: SnsTopicSubSystemFacade
+) : SnsTopicFactoryService{
 
     /**
      * aws sns topic을 생성해주는 서비스
@@ -25,7 +28,7 @@ class SnsTopicFactoryServiceImpl(val snsTopicSubSystemFacade: SnsTopicSubSystemF
         val topicRequest = snsTopicSubSystemFacade.createTopicRequest(topicName)
 
         // topic 생성
-        val createTopic = SnsClient.create().createTopic(topicRequest)
+        val createTopic = credentialService.getSnsClient().createTopic(topicRequest)
 
         // topic이 성공적으로 생성됐는지 assertion
         snsTopicSubSystemFacade.sdkHealthChecker(createTopic)

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -1,9 +1,9 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
 import org.springframework.stereotype.Service
+import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsTopicSubSystemFacade
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
-import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 
 /**
  * sns topic을 생성해주는 서비스
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.sns.model.CreateTopicResponse
  * @since 1.0.0
  */
 @Service
-class SnsTopicFactoryServiceImpl : SnsTopicFactoryService{
+class SnsTopicFactoryServiceImpl(val snsTopicSubSystemFacade: SnsTopicSubSystemFacade) : SnsTopicFactoryService{
 
     /**
      * aws sns topic을 생성해주는 서비스
@@ -22,39 +22,13 @@ class SnsTopicFactoryServiceImpl : SnsTopicFactoryService{
     override fun createTopic(topicName: String) {
 
         // topicRequest 생성
-        val topicRequest = createTopicRequest(topicName)
+        val topicRequest = snsTopicSubSystemFacade.createTopicRequest(topicName)
 
         // topic 생성
         val createTopic = SnsClient.create().createTopic(topicRequest)
 
         // topic이 성공적으로 생성됐는지 assertion
-        sdkHealthChecker(createTopic)
+        snsTopicSubSystemFacade.sdkHealthChecker(createTopic)
     }
 
-    /**
-     * aws sns 의 topic 을 생성해주는 method
-     * https://ap-northeast-2.console.aws.amazon.com/sns/v3/home?region=ap-northeast-2#/homepage
-     *
-     * @since 1.0.0
-     */
-    private fun createTopicRequest(topicName: String): CreateTopicRequest? {
-
-        return CreateTopicRequest.builder()
-            .name(topicName)
-            .build()
-    }
-
-    /**
-     * sdkHttpResponse가 !isOk 대해 Exception을 발생시켜주는 HealthChecker
-     *
-     * @since 1.0.0
-     */
-    private fun sdkHealthChecker(createTopic: CreateTopicResponse) {
-        // sdkHttpResponse checker
-        val sdkHttpResponse = createTopic.sdkHttpResponse()
-
-        if (!sdkHttpResponse.isSuccessful) {
-            throw Exception("sdkHttpResponseException ====== code: ${sdkHttpResponse.statusCode()} message: ${sdkHttpResponse.statusText()}")
-        }
-    }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -1,0 +1,60 @@
+package site.hirecruit.hr.thirdParty.aws.sns.service
+
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sns.SnsClient
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse
+
+/**
+ * sns topic을 생성해주는 서비스
+ *
+ * @author 전지환
+ * @since 1.0.0
+ */
+@Service
+class SnsTopicFactoryServiceImpl : SnsTopicFactoryService{
+
+    /**
+     * aws sns topic을 생성해주는 서비스
+     *
+     * @see CreateTopicRequest.name - Constraints
+     */
+    override fun createTopic(topicName: String) {
+
+        // topicRequest 생성
+        val topicRequest = createTopicRequest(topicName)
+
+        // topic 생성
+        val createTopic = SnsClient.create().createTopic(topicRequest)
+
+        // topic이 성공적으로 생성됐는지 assertion
+        sdkHealthChecker(createTopic)
+    }
+
+    /**
+     * aws sns 의 topic 을 생성해주는 method
+     * https://ap-northeast-2.console.aws.amazon.com/sns/v3/home?region=ap-northeast-2#/homepage
+     *
+     * @since 1.0.0
+     */
+    private fun createTopicRequest(topicName: String): CreateTopicRequest? {
+
+        return CreateTopicRequest.builder()
+            .name(topicName)
+            .build()
+    }
+
+    /**
+     * sdkHttpResponse가 !isOk 대해 Exception을 발생시켜주는 HealthChecker
+     *
+     * @since 1.0.0
+     */
+    private fun sdkHealthChecker(createTopic: CreateTopicResponse) {
+        // sdkHttpResponse checker
+        val sdkHttpResponse = createTopic.sdkHttpResponse()
+
+        if (!sdkHttpResponse.isSuccessful) {
+            throw Exception("sdkHttpResponseException ====== code: ${sdkHttpResponse.statusCode()} message: ${sdkHttpResponse.statusText()}")
+        }
+    }
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -1,0 +1,36 @@
+package site.hirecruit.hr.thirdParty.aws.sns.service.facade
+
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse
+
+@Service
+class SnsTopicSubSystemFacade {
+
+    /**
+     * aws sns 의 topic 을 생성해주는 method
+     * https://ap-northeast-2.console.aws.amazon.com/sns/v3/home?region=ap-northeast-2#/homepage
+     *
+     * @since 1.0.0
+     */
+    fun createTopicRequest(topicName: String): CreateTopicRequest? {
+
+        return CreateTopicRequest.builder()
+            .name(topicName)
+            .build()
+    }
+
+    /**
+     * sdkHttpResponse가 !isOk 대해 Exception을 발생시켜주는 HealthChecker
+     *
+     * @since 1.0.0
+     */
+    fun sdkHealthChecker(createTopic: CreateTopicResponse) {
+        // sdkHttpResponse checker
+        val sdkHttpResponse = createTopic.sdkHttpResponse()
+
+        if (!sdkHttpResponse.isSuccessful) {
+            throw Exception("sdkHttpResponseException ====== code: ${sdkHttpResponse.statusCode()} message: ${sdkHttpResponse.statusText()}")
+        }
+    }
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -13,7 +13,7 @@ class SnsTopicSubSystemFacade {
      *
      * @since 1.0.0
      */
-    fun createTopicRequest(topicName: String): CreateTopicRequest? {
+    fun createTopicRequest(topicName: String): CreateTopicRequest {
 
         return CreateTopicRequest.builder()
             .name(topicName)

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -3,7 +3,6 @@ package site.hirecruit.hr.thirdParty.aws.sns.service.facade
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
-import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 
 @Service
 class SnsTopicSubSystemFacade {
@@ -33,24 +32,13 @@ class SnsTopicSubSystemFacade {
         // topic 생성
         val createTopicResponse = snsClient.createTopic(topicRequest)
 
-        // topic이 성공적으로 생성됐는지 assertion
-        return isSdkHttpResponseHealthy(createTopicResponse)
-    }
-
-    /**
-     * sdkHttpResponse가 !isOk 대해 Exception을 발생시켜주는 HealthChecker
-     *
-     * @param createTopicResponse
-     * @throws Exception
-     */
-    fun isSdkHttpResponseHealthy(createTopicResponse: CreateTopicResponse) : Boolean {
-
+        // sdkHttpResponse가 !isOk 대해 Exception을 발생시켜주는 HealthChecker
         val sdkHttpResponse = createTopicResponse.sdkHttpResponse()
-
         if (!sdkHttpResponse.isSuccessful){
             throw Exception("sdkHttpResponse가 기대값 isSuccessful를 만족시키지 못 함 ======== code: ${sdkHttpResponse.statusCode()}  msg: ${sdkHttpResponse.statusText()}")
         }
 
         return true
     }
+
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -1,6 +1,7 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service.facade
 
 import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
 import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 
@@ -21,16 +22,35 @@ class SnsTopicSubSystemFacade {
     }
 
     /**
+     * snsClient, aws api가 직접적으로 개입하는 로직
+     *
+     * @param topicRequest
+     * @param snsClient sns 서비스를 사용할 자격이 있는 client
+     * @throws Exception request가 정상적으로 처리되지 않았을 때.
+     */
+    fun servingTopicRequestToSnsClient(topicRequest: CreateTopicRequest, snsClient: SnsClient) : Boolean {
+
+        // topic 생성
+        val createTopicResponse = snsClient.createTopic(topicRequest)
+
+        // topic이 성공적으로 생성됐는지 assertion
+        return isSdkHttpResponseHealthy(createTopicResponse)
+    }
+
+    /**
      * sdkHttpResponse가 !isOk 대해 Exception을 발생시켜주는 HealthChecker
      *
-     * @since 1.0.0
+     * @param createTopicResponse
+     * @throws Exception
      */
-    fun sdkHealthChecker(createTopic: CreateTopicResponse) {
-        // sdkHttpResponse checker
-        val sdkHttpResponse = createTopic.sdkHttpResponse()
+    fun isSdkHttpResponseHealthy(createTopicResponse: CreateTopicResponse) : Boolean {
 
-        if (!sdkHttpResponse.isSuccessful) {
-            throw Exception("sdkHttpResponseException ====== code: ${sdkHttpResponse.statusCode()} message: ${sdkHttpResponse.statusText()}")
+        val sdkHttpResponse = createTopicResponse.sdkHttpResponse()
+
+        if (!sdkHttpResponse.isSuccessful){
+            throw Exception("sdkHttpResponse가 기대값 isSuccessful를 만족시키지 못 함 ======== code: ${sdkHttpResponse.statusCode()}  msg: ${sdkHttpResponse.statusText()}")
         }
+
+        return true
     }
 }

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -17,7 +17,7 @@ class SnsTopicFactoryServiceImplTest{
 
 
     @Test
-    @DisplayName("sns topic이 정상적으로 생성된다:: 실제로 IAM과 aws-api 개입하는 테스트")
+    @DisplayName("SnsClient의 sns에 topic이 정상적으로 생성된다")
     fun snsTopicCreateSuccessful(){
         // mocking
         val snsClient: SnsClient = mockk()

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -1,0 +1,5 @@
+package site.hirecruit.hr.thirdParty.aws.sns.service
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class SnsTopicFactoryServiceImplTest

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -7,13 +7,11 @@ import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
-import org.springframework.boot.test.context.SpringBootTest
 import site.hirecruit.hr.domain.test_util.LocalTest
 import site.hirecruit.hr.thirdParty.aws.service.CredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsTopicSubSystemFacade
 import software.amazon.awssdk.services.sns.SnsClient
 
-@SpringBootTest
 @LocalTest
 class SnsTopicFactoryServiceImplTest{
 
@@ -36,7 +34,6 @@ class SnsTopicFactoryServiceImplTest{
         every { snsTopicSubSystemFacade.createTopicRequest(any()) }.returns(any())
         every { credentialService.getSnsClient() }.returns(snsClient)
         every { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), snsClient) }.returns(true)
-        every { snsTopicSubSystemFacade.isSdkHttpResponseHealthy(any()) }.returns(true)
 
         // When
         snsTopicFactoryService.createTopic(RandomString.make(5))
@@ -44,6 +41,6 @@ class SnsTopicFactoryServiceImplTest{
         // Then
         verify(exactly = 1) { snsTopicSubSystemFacade.createTopicRequest(any()) }
         verify(exactly = 1) { credentialService.getSnsClient() }
-        verify(exactly = 1) { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), any()) }
+        verify(exactly = 1) { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), snsClient) }
     }
 }

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -1,5 +1,44 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
-import org.junit.jupiter.api.Assertions.*
+import io.mockk.every
+import io.mockk.mockk
+import net.bytebuddy.utility.RandomString
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import site.hirecruit.hr.domain.test_util.LocalTest
+import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsTopicSubSystemFacade
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest
 
-internal class SnsTopicFactoryServiceImplTest
+@SpringBootTest
+@LocalTest
+class SnsTopicFactoryServiceImplTest{
+
+
+    @Test
+    @DisplayName("sns topic이 정상적으로 생성된다")
+    fun snsTopicCreateSuccessful(
+        @Autowired snsTopicFactoryService: SnsTopicFactoryService
+
+    ){
+        // mocking
+        val snsTopicSubSystemFacade: SnsTopicSubSystemFacade = mockk()
+        val createTopicRequest: CreateTopicRequest = mockk()
+
+        // Given
+        every { snsTopicSubSystemFacade.createTopicRequest(RandomString.make(5)) }.returns(mockTopicRequest())
+
+        // When ~ Then
+        assertDoesNotThrow {
+            snsTopicFactoryService.createTopic(RandomString.make(5))
+        }
+    }
+
+    private fun mockTopicRequest() : CreateTopicRequest {
+        return CreateTopicRequest.builder()
+            .name(RandomString.make(5))
+            .build()
+    }
+}

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -2,15 +2,16 @@ package site.hirecruit.hr.thirdParty.aws.sns.service
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.springframework.beans.factory.annotation.Autowired
+import org.mockito.kotlin.any
 import org.springframework.boot.test.context.SpringBootTest
 import site.hirecruit.hr.domain.test_util.LocalTest
+import site.hirecruit.hr.thirdParty.aws.service.CredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsTopicSubSystemFacade
-import software.amazon.awssdk.services.sns.model.CreateTopicRequest
+import software.amazon.awssdk.services.sns.SnsClient
 
 @SpringBootTest
 @LocalTest
@@ -18,27 +19,31 @@ class SnsTopicFactoryServiceImplTest{
 
 
     @Test
-    @DisplayName("sns topic이 정상적으로 생성된다")
-    fun snsTopicCreateSuccessful(
-        @Autowired snsTopicFactoryService: SnsTopicFactoryService
-
-    ){
+    @DisplayName("sns topic이 정상적으로 생성된다:: 실제로 IAM과 aws-api 개입하는 테스트")
+    fun snsTopicCreateSuccessful(){
         // mocking
+        val snsClient: SnsClient = mockk()
+        val credentialService: CredentialService = mockk()
         val snsTopicSubSystemFacade: SnsTopicSubSystemFacade = mockk()
-        val createTopicRequest: CreateTopicRequest = mockk()
+        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(credentialService, snsTopicSubSystemFacade)
 
-        // Given
-        every { snsTopicSubSystemFacade.createTopicRequest(RandomString.make(5)) }.returns(mockTopicRequest())
+        /**
+         * 1. topicReqest는 mockTopicRequest를 리턴한다.
+         * 2. 가짜 snsClient를 리턴한다. (실제 snsClient를 사용하지 않는다)
+         * 2. snsClient는 정상적으로 true를 리턴한다.
+         * 3. snsClient는 HttpStatus isSuccessful를 리턴한다.
+         */
+        every { snsTopicSubSystemFacade.createTopicRequest(any()) }.returns(any())
+        every { credentialService.getSnsClient() }.returns(snsClient)
+        every { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), snsClient) }.returns(true)
+        every { snsTopicSubSystemFacade.isSdkHttpResponseHealthy(any()) }.returns(true)
 
-        // When ~ Then
-        assertDoesNotThrow {
-            snsTopicFactoryService.createTopic(RandomString.make(5))
-        }
-    }
+        // When
+        snsTopicFactoryService.createTopic(RandomString.make(5))
 
-    private fun mockTopicRequest() : CreateTopicRequest {
-        return CreateTopicRequest.builder()
-            .name(RandomString.make(5))
-            .build()
+        // Then
+        verify(exactly = 1) { snsTopicSubSystemFacade.createTopicRequest(any()) }
+        verify(exactly = 1) { credentialService.getSnsClient() }
+        verify(exactly = 1) { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), any()) }
     }
 }


### PR DESCRIPTION
## 작업 내용
* create topic 피처 개발

![sns-topic-generated](https://user-images.githubusercontent.com/67095821/169645656-58dedc2a-b97d-46a2-9391-30efb226f9ab.png)

## 부가 설명
topic(주제)의 역할은.. 한마디로 Grouping이다.
회원가입 주제, 멘티로 등록 주제 ... 등등 만들어 해당 주제(카테고리)에 알맞는 sns 를 보낼 수 있게 한다.

1. aws-sns 주제(대분류)를 만들어 
2. 그 주제를 구독할 수 있게 한다. 
3. 그 주제를 구독한 구독자들에게 알림을 보낼 수 있도록 해준다.

![CleanShot 2022-05-21 at 18 22 34@2x](https://user-images.githubusercontent.com/67095821/169645140-1790cc3f-0ce6-4e72-8ce9-1f62ce2571a5.png)

## 리뷰 받고 싶은 부분
최대한 TDD 로 개발하려고 노력했다. 
가급적 private 메소드는 피하고 mocking 하기 쉽게끔 facade-pattern 으로 클라이언트(개발자)가 알 필요 없는 서브 시스템을 숨겼다.

#### <의사결정 주제>
* `SnsTopicSubSystemFacade/servingTopicRequestToSnsClient()` 와 `SnsTopicSubSystemFacade/isSdkHttpResponseHealthy()` 를 합쳐야 할까 ?

`servingTopicRequestToSnsClient()` 메소드가 `isSdkHttpResponseHealthy()` 리턴값에 100% 의존하고 있어 합쳐도 될 것 같다는 생각도 들지만. 나중에 HttpResponse 의 결과 값을 mocking(조작) 하기 위해서는 분리하는것도 좋다는 생각이 든다.

#### <현재>
두 메소드가 분리 되어있어. mockk 테스트에서는 `servingTopicRequestToSnsClient()`가 `isSdkHttpResponseHealthy()`결과값을 바로 return 하기 때문에(return 라인에서) verify로 해당 라인이 지나감을 감지하지 못해 "검증이 되지 않는다."