### PR TITLE
Feature/aws sns modules [display all topic: 생성된 모든 토픽 가져오기]

### DIFF
--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
@@ -2,4 +2,5 @@ package site.hirecruit.hr.thirdParty.aws.sns.service
 
 interface SnsTopicFactoryService {
     fun createTopic(topicName: String)
+    fun displayAllTopics()
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
@@ -1,8 +1,9 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 import software.amazon.awssdk.services.sns.model.Topic
 
 interface SnsTopicFactoryService {
-    fun createTopic(topicName: String)
+    fun createTopic(topicName: String) : CreateTopicResponse
     fun displayAllTopics() : MutableList<Topic>
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
@@ -1,6 +1,8 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
+import software.amazon.awssdk.services.sns.model.Topic
+
 interface SnsTopicFactoryService {
     fun createTopic(topicName: String)
-    fun displayAllTopics()
+    fun displayAllTopics() : MutableList<Topic>
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -31,7 +31,7 @@ class SnsTopicFactoryServiceImpl(
         val topicRequest = snsTopicSubSystemFacade.createTopicRequest(topicName)
 
         // topicRequest를 aws-sns-api가 처리하도록 serving 함.
-        return snsTopicSubSystemFacade.servingTopicRequestToSnsClient(topicRequest, credentialService.getSnsClient())
+        return snsTopicSubSystemFacade.servingTopicRequestToSnsClient(topicRequest, credentialService.getSnsClient())!!
     }
 
     /**

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import site.hirecruit.hr.thirdParty.aws.service.CredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsTopicSubSystemFacade
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 import software.amazon.awssdk.services.sns.model.Topic
 
 /**
@@ -24,14 +25,13 @@ class SnsTopicFactoryServiceImpl(
      * @see CreateTopicRequest.name - Constraints: topicName must be ASCII 0 ~ 256
      * @see SnsTopicSubSystemFacade.servingTopicRequestToSnsClient - aws-api가 직접적으로 로직을 처리 함
      */
-    override fun createTopic(topicName: String) {
+    override fun createTopic(topicName: String): CreateTopicResponse {
 
         // topicRequest 생성
         val topicRequest = snsTopicSubSystemFacade.createTopicRequest(topicName)
 
         // topicRequest를 aws-sns-api가 처리하도록 serving 함.
-        snsTopicSubSystemFacade.servingTopicRequestToSnsClient(topicRequest, credentialService.getSnsClient())
-
+        return snsTopicSubSystemFacade.servingTopicRequestToSnsClient(topicRequest, credentialService.getSnsClient())
     }
 
     /**

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import site.hirecruit.hr.thirdParty.aws.service.CredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsTopicSubSystemFacade
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
+import software.amazon.awssdk.services.sns.model.Topic
 
 /**
  * sns topic을 생성해주는 서비스
@@ -33,9 +34,16 @@ class SnsTopicFactoryServiceImpl(
 
     }
 
-    override fun displayAllTopics() {
+    /**
+     * aws sns 모든 topic을 가져오는 서비스
+     *
+     * @return ListTopicResponse - MutableList<T> 읽기, 쓰기가 가능한 객체
+     */
+    override fun displayAllTopics() : MutableList<Topic> {
         val listTopicRequest = snsTopicSubSystemFacade.createListTopicRequest()
-        snsTopicSubSystemFacade.getAllTopicsAsList(listTopicRequest, credentialService.getSnsClient())
+
+        return snsTopicSubSystemFacade.getAllTopicsAsList(listTopicRequest, credentialService.getSnsClient()).topics()
+            ?: throw NoSuchElementException("요청하신 getAllTopics의 결과: topics element가 존재하지 않습니다.")
     }
 
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -33,4 +33,9 @@ class SnsTopicFactoryServiceImpl(
 
     }
 
+    override fun displayAllTopics() {
+        val listTopicRequest = snsTopicSubSystemFacade.createListTopicRequest()
+        snsTopicSubSystemFacade.getAllTopicsAsList(listTopicRequest, credentialService.getSnsClient())
+    }
+
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -24,6 +24,7 @@ class SnsTopicFactoryServiceImpl(
      *
      * @see CreateTopicRequest.name - Constraints: topicName must be ASCII 0 ~ 256
      * @see SnsTopicSubSystemFacade.servingTopicRequestToSnsClient - aws-api가 직접적으로 로직을 처리 함
+     * @throws NoSuchElementException - 요청은 isSuccessful 이지만 topic 결과가 없을 때.
      */
     override fun createTopic(topicName: String): CreateTopicResponse {
 

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -31,7 +31,9 @@ class SnsTopicFactoryServiceImpl(
         val topicRequest = snsTopicSubSystemFacade.createTopicRequest(topicName)
 
         // topicRequest를 aws-sns-api가 처리하도록 serving 함.
-        return snsTopicSubSystemFacade.servingTopicRequestToSnsClient(topicRequest, credentialService.getSnsClient())!!
+        return snsTopicSubSystemFacade.servingTopicRequestToSnsClient(topicRequest, credentialService.getSnsClient())
+            ?: throw NoSuchElementException("요청하신 createTopic 결과: CreateTopicResponse가 존재하지 않습니다.")
+
     }
 
     /**

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -37,12 +37,13 @@ class SnsTopicFactoryServiceImpl(
     /**
      * aws sns 모든 topic을 가져오는 서비스
      *
+     * @throws NoSuchElementException getAllTopicsAsList로 반환된 결과가 비어있는, 없는 공간일 때.
      * @return ListTopicResponse - MutableList<T> 읽기, 쓰기가 가능한 객체
      */
     override fun displayAllTopics() : MutableList<Topic> {
         val listTopicRequest = snsTopicSubSystemFacade.createListTopicRequest()
 
-        return snsTopicSubSystemFacade.getAllTopicsAsList(listTopicRequest, credentialService.getSnsClient()).topics()
+        return snsTopicSubSystemFacade.getAllTopicsAsList(listTopicRequest, credentialService.getSnsClient())?.topics()
             ?: throw NoSuchElementException("요청하신 getAllTopics의 결과: topics element가 존재하지 않습니다.")
     }
 

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -42,7 +42,7 @@ class SnsTopicSubSystemFacade {
      * @throws Exception request가 정상적으로 처리되지 않았을 때.
      * @return createTopicResponse topic request 결과
      */
-    fun servingTopicRequestToSnsClient(topicRequest: CreateTopicRequest, snsClient: SnsClient) : CreateTopicResponse? {
+    fun servingTopicRequestToSnsClient(topicRequest: CreateTopicRequest, snsClient: SnsClient) : CreateTopicResponse {
 
         // topic 생성
         val createTopicResponse = snsClient.createTopic(topicRequest)

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import software.amazon.awssdk.http.SdkHttpResponse
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
+import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 import software.amazon.awssdk.services.sns.model.ListTopicsRequest
 import software.amazon.awssdk.services.sns.model.ListTopicsResponse
 
@@ -39,8 +40,9 @@ class SnsTopicSubSystemFacade {
      * @param topicRequest
      * @param snsClient sns 서비스를 사용할 자격이 있는 client
      * @throws Exception request가 정상적으로 처리되지 않았을 때.
+     * @return createTopicResponse topic request 결과
      */
-    fun servingTopicRequestToSnsClient(topicRequest: CreateTopicRequest, snsClient: SnsClient) : Boolean {
+    fun servingTopicRequestToSnsClient(topicRequest: CreateTopicRequest, snsClient: SnsClient) : CreateTopicResponse? {
 
         // topic 생성
         val createTopicResponse = snsClient.createTopic(topicRequest)
@@ -48,7 +50,7 @@ class SnsTopicSubSystemFacade {
         // topic이 정상적으로 생성 됐는지 check
         isSdkHttpResponseIsSuccessful(createTopicResponse.sdkHttpResponse())
 
-        return true
+        return createTopicResponse
     }
 
     /**

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -42,7 +42,7 @@ class SnsTopicSubSystemFacade {
      * @throws Exception request가 정상적으로 처리되지 않았을 때.
      * @return createTopicResponse topic request 결과
      */
-    fun servingTopicRequestToSnsClient(topicRequest: CreateTopicRequest, snsClient: SnsClient) : CreateTopicResponse {
+    fun servingTopicRequestToSnsClient(topicRequest: CreateTopicRequest, snsClient: SnsClient) : CreateTopicResponse? {
 
         // topic 생성
         val createTopicResponse = snsClient.createTopic(topicRequest)

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -59,7 +59,7 @@ class SnsTopicSubSystemFacade {
      * @param listTopicRequest
      * @return listTopics
      */
-    fun getAllTopicsAsList(listTopicRequest: ListTopicsRequest, snsClient: SnsClient): ListTopicsResponse {
+    fun getAllTopicsAsList(listTopicRequest: ListTopicsRequest, snsClient: SnsClient): ListTopicsResponse? {
         val listTopics = snsClient.listTopics(listTopicRequest)
         isSdkHttpResponseIsSuccessful(listTopics.sdkHttpResponse())
 

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -43,7 +43,7 @@ class SnsTopicSubSystemFacade {
     /**
      * snsClient, aws api가 직접적으로 개입하는 로직
      *
-     * @param topicRequest
+     * @param topicRequest nullable
      * @param snsClient sns 서비스를 사용할 자격이 있는 client
      * @throws Exception request가 정상적으로 처리되지 않았을 때.
      * @return createTopicResponse topic request 결과
@@ -62,7 +62,7 @@ class SnsTopicSubSystemFacade {
     /**
      * 모든 sns topic 들을 가져오는 로직
      *
-     * @param listTopicRequest
+     * @param listTopicRequest nullable
      * @return listTopics
      */
     fun getAllTopicsAsList(listTopicRequest: ListTopicsRequest, snsClient: SnsClient): ListTopicsResponse? {

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -8,6 +8,12 @@ import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 import software.amazon.awssdk.services.sns.model.ListTopicsRequest
 import software.amazon.awssdk.services.sns.model.ListTopicsResponse
 
+/**
+ * service layer -> facade layer -> sdk
+ *
+ * @since 1.0.0
+ * @author 전지환
+ */
 @Service
 class SnsTopicSubSystemFacade {
 

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -57,9 +57,9 @@ class SnsTopicSubSystemFacade {
      * 모든 sns topic 들을 가져오는 로직
      *
      * @param listTopicRequest
-     * @return listTopics nullable
+     * @return listTopics
      */
-    fun getAllTopicsAsList(listTopicRequest: ListTopicsRequest, snsClient: SnsClient): ListTopicsResponse? {
+    fun getAllTopicsAsList(listTopicRequest: ListTopicsRequest, snsClient: SnsClient): ListTopicsResponse {
         val listTopics = snsClient.listTopics(listTopicRequest)
         isSdkHttpResponseIsSuccessful(listTopics.sdkHttpResponse())
 

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -33,7 +33,7 @@ class SnsTopicFactoryServiceImplTest{
          */
         every { snsTopicSubSystemFacade.createTopicRequest(any()) }.returns(any())
         every { credentialService.getSnsClient() }.returns(snsClient)
-        every { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), snsClient) }.returns(true)
+        every { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), snsClient) }.returns(any())
 
         // When
         snsTopicFactoryService.createTopic(RandomString.make(5))

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -36,8 +36,10 @@ class SnsTopicFactoryServiceImplTest{
         every { credentialService.getSnsClient() }.returns(snsClient)
         every { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), snsClient) }.returns(any())
 
-        // When
-        snsTopicFactoryService.createTopic(RandomString.make(5))
+        // When:: mockSnsClient는 아무런 sns topic 도 생성하지 못할것을 확신한다.
+        assertThrows<NoSuchElementException> {
+            snsTopicFactoryService.createTopic(RandomString.make(5))
+        }
 
         // Then
         verify(exactly = 1) { snsTopicSubSystemFacade.createTopicRequest(any()) }

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import site.hirecruit.hr.domain.test_util.LocalTest
 import site.hirecruit.hr.thirdParty.aws.service.CredentialService
@@ -42,5 +43,29 @@ class SnsTopicFactoryServiceImplTest{
         verify(exactly = 1) { snsTopicSubSystemFacade.createTopicRequest(any()) }
         verify(exactly = 1) { credentialService.getSnsClient() }
         verify(exactly = 1) { snsTopicSubSystemFacade.servingTopicRequestToSnsClient(any(), snsClient) }
+    }
+
+    @Test
+    @DisplayName("SnsClient에 등록된 topic들이 모두 조회된다.")
+    fun snsTopicsWereDisplay(){
+        // Given:: mocking
+        val snsClient : SnsClient = mockk()
+        val credentialService : CredentialService = mockk()
+        val snsTopicSubSystemFacade : SnsTopicSubSystemFacade = mockk()
+        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(credentialService, snsTopicSubSystemFacade)
+
+        // Given:: stubs
+        every { snsTopicSubSystemFacade.createListTopicRequest() }.returns(any())
+        every { credentialService.getSnsClient() }.returns(snsClient)
+        every { snsTopicSubSystemFacade.getAllTopicsAsList(any(), credentialService.getSnsClient()) }.returns(any())
+
+        // when:: mockSnsClient는 아무런 sns topic 도 가지지 않을 것을 확신한다.
+        assertThrows<NoSuchElementException> {
+            snsTopicFactoryService.displayAllTopics()
+        }
+
+        // Then
+        verify(exactly = 1) { snsTopicSubSystemFacade.createListTopicRequest() }
+        verify(exactly = 1) { credentialService.getSnsClient() }
     }
 }


### PR DESCRIPTION
## 개요
* aws sns 생성된 모든 토픽을 가져오는 비즈니스 로직 작성

## 참고사항
* 아직 api spec 이 정해지지 않아서 반환타입은 확정되지 않음

## 변경사항
* `NullPointerException`을 터지게 하기 보다는 요소가 없음을 알려주는 Runtime 계열의 `NoSuchElementException`으로 예외처리 함.
* sdkHttpResponse status 에 대해서 isSuccessful인지 검사하는 로직을 메소드화 시킴. (라이브러리 피처를 개발할때마다 중복되는 로직을 분리 함)