### PR TITLE
회원가입 로직 완료

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ allOpen {
     annotation("javax.persistence.Embeddable")
     annotation("org.springframework.context.annotation.Configuration")
     annotation("org.springframework.stereotype.Repository")
+    annotation("org.aspectj.lang.annotation.Aspect")
 }
 
 noArg {

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
@@ -19,7 +19,7 @@ val log = KotlinLogging.logger {}
  */
 @Component
 @Aspect
-private open class UserAuthAspect (
+private class UserAuthAspect (
     private val httpSession: HttpSession
 ) {
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
@@ -9,7 +9,7 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.global.data.SessionAttribute
 import javax.servlet.http.HttpSession
 
-val log = KotlinLogging.logger {}
+private val log = KotlinLogging.logger {}
 
 /**
  * UserAuth관련 AOP

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpSession
  */
 @Component
 @Aspect
-private open class UserRegistrationAspect(
+private class UserRegistrationAspect(
     private val tempUserRepository: TempUserRepository,
     private val httpSession: HttpSession
 ) {

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
@@ -1,0 +1,51 @@
+package site.hirecruit.hr.domain.auth.aop
+
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.repository.TempUserRepository
+import site.hirecruit.hr.global.data.SessionAttribute
+import javax.servlet.http.HttpSession
+
+/**
+ * [site.hirecruit.hr.domain.auth.service.UserRegistrationService]의 횡단 관심사를 모아놓은 AOP 클래스
+ *
+ * @author 정시원
+ * @since 1.0
+ * @see site.hirecruit.hr.domain.auth.service.UserRegistrationService
+ */
+@Component
+@Aspect
+private open class UserRegistrationAspect(
+    private val tempUserRepository: TempUserRepository,
+    private val httpSession: HttpSession
+) {
+
+    @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserRegistrationService+.registration(..))")
+    private fun userRegistrationService_registrationMethodPointCut(){}
+
+    /**
+     * 회원가입 후 진행해야 하는 횡단 관심사
+     * 1. 임시유저 제거
+     * 2. 세션에 유저 인증 정보 업데이트
+     */
+    @AfterReturning(
+        "userRegistrationService_registrationMethodPointCut()",
+        returning = "authUserInfo"
+    )
+    fun afterRegistrationMethod(authUserInfo: AuthUserInfo){
+        deleteTempUser(authUserInfo.githubId)
+        sessionUserAuthInfoUpdate(authUserInfo)
+    }
+
+    private fun deleteTempUser(githubId: Long){
+        tempUserRepository.deleteById(githubId)
+    }
+
+    private fun sessionUserAuthInfoUpdate(authUserInfo: AuthUserInfo){
+        httpSession.setAttribute(SessionAttribute.AUTH_USER_INFO.attributeName, authUserInfo)
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
@@ -1,5 +1,6 @@
 package site.hirecruit.hr.domain.auth.aop
 
+import mu.KotlinLogging
 import org.aspectj.lang.annotation.AfterReturning
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Pointcut
@@ -8,6 +9,8 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.global.data.SessionAttribute
 import javax.servlet.http.HttpSession
+
+private val log = KotlinLogging.logger {}
 
 /**
  * [site.hirecruit.hr.domain.auth.service.UserRegistrationService]의 횡단 관심사를 모아놓은 AOP 클래스
@@ -36,6 +39,8 @@ private class UserRegistrationAspect(
         returning = "authUserInfo"
     )
     fun afterRegistrationMethod(authUserInfo: AuthUserInfo){
+        log.debug("UserRegistrationAspect.afterRegistrationMethod activate")
+        log.debug("AuthUserInfo='$authUserInfo'")
         deleteTempUser(authUserInfo.githubId)
         sessionUserAuthInfoUpdate(authUserInfo)
     }

--- a/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
@@ -1,0 +1,32 @@
+package site.hirecruit.hr.domain.auth.controller
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import site.hirecruit.hr.domain.auth.service.UserRegistrationService
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
+import springfox.documentation.annotations.ApiIgnore
+import javax.validation.Valid
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthController(
+    private val userRegistrationService: UserRegistrationService
+) {
+
+    @PostMapping("/registration")
+    private fun registration(
+        @CurrentAuthUserInfo @ApiIgnore
+        authUserInfo: AuthUserInfo,
+
+        @RequestBody  @Valid
+        userRegistrationDto: UserRegistrationDto
+    ): ResponseEntity<Map<String, Long>>{
+        val registeredAuthUserInfo = userRegistrationService.registration(authUserInfo, userRegistrationDto)
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(mapOf("githubId" to registeredAuthUserInfo.githubId))
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/UserRegistrationDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/UserRegistrationDto.kt
@@ -1,6 +1,6 @@
 package site.hirecruit.hr.domain.auth.dto
 
-import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonProperty
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
@@ -12,6 +12,6 @@ data class UserRegistrationDto(
 
     val name: String? = null,
 
-    @field:JsonAlias("worker") @field:NotNull
+    @field:JsonProperty("worker") @field:NotNull
     val workerDto: WorkerDto.Registration
 )

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/UserRegistrationDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/UserRegistrationDto.kt
@@ -1,0 +1,17 @@
+package site.hirecruit.hr.domain.auth.dto
+
+import com.fasterxml.jackson.annotation.JsonAlias
+import site.hirecruit.hr.domain.worker.dto.WorkerDto
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+data class UserRegistrationDto(
+    @field:NotBlank @field:Email
+    val email: String,
+
+    val name: String? = null,
+
+    @field:JsonAlias("worker") @field:NotNull
+    val workerDto: WorkerDto.Registration
+)

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/Role.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/Role.kt
@@ -5,5 +5,6 @@ enum class Role(
     val title: String
 ){
     GUEST("ROLE_GUEST", "게스트"),  // 인증하지 않은 직장인
-    CLIENT("ROLE_CLIENT", "사용자");
+    CLIENT("ROLE_CLIENT", "사용자"),
+    UNAUTHENTICATED_EMAIL("ROLE_UNAUTHENTICATED_EMAIL", "email 인증되지 않은 사용자")
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
@@ -28,4 +28,22 @@ class UserEntity(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val userId: Long? = null
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is UserEntity) return false
+
+        if (githubId != other.githubId) return false
+        if (userId != other.userId) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = githubId.hashCode()
+        result = 31 * result + (userId?.hashCode() ?: 0)
+        return result
+    }
+
+
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/EmailAuthenticationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/EmailAuthenticationService.kt
@@ -1,6 +1,7 @@
 package site.hirecruit.hr.domain.auth.service
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import java.util.concurrent.CompletableFuture
 
 /**
  * email인증 서비스

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/EmailAuthenticationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/EmailAuthenticationService.kt
@@ -1,0 +1,30 @@
+package site.hirecruit.hr.domain.auth.service
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+
+/**
+ * email인증 서비스
+ *
+ * @author 정시원
+ * @since 1.0.
+ */
+interface EmailAuthenticationService {
+
+    /**
+     * email 인증 메일를 전송한다.
+     *
+     * @param authUserInfo 인증 메일을 보낼 회원 정보
+     * @param email 인증 메일을 보낼 email
+     * @return 인증에 사용된 임의의 토큰
+     */
+    fun send(authUserInfo: AuthUserInfo, email: String): String
+
+    /**
+     * email로 전송한 토큰을 검증한다.
+     *
+     * @return
+     * - true: 토큰이 유효함
+     * - false: 토큰이 유효하지 않음
+     */
+    fun tokenVerification(email: String): Boolean
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.kt
@@ -4,7 +4,7 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
 
 /**
- * 회원가입을 진행합니다.
+ * 유저생성 서비스
  *
  * @author 정시원
  * @version 1.0
@@ -12,7 +12,9 @@ import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
 interface UserRegistrationService {
 
     /**
-     * 임시 유저에 추가 정보를 입력하여 회원가입을 완료합니다.
+     * 유저를 생성합니다.
+     *
+     * @return [AuthUserInfo] - 임시 유저의 정보
      */
-    fun registration(authUserInfo: AuthUserInfo, userRegistrationInfo: UserRegistrationDto)
+    fun registration(authUserInfo: AuthUserInfo, userRegistrationInfo: UserRegistrationDto): AuthUserInfo
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.kt
@@ -1,0 +1,18 @@
+package site.hirecruit.hr.domain.auth.service
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+
+/**
+ * 회원가입을 진행합니다.
+ *
+ * @author 정시원
+ * @version 1.0
+ */
+interface UserRegistrationService {
+
+    /**
+     * 임시 유저에 추가 정보를 입력하여 회원가입을 완료합니다.
+     */
+    fun registration(authUserInfo: AuthUserInfo, userRegistrationInfo: UserRegistrationDto)
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/EmailAuthenticationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/EmailAuthenticationServiceImpl.kt
@@ -1,0 +1,16 @@
+package site.hirecruit.hr.domain.auth.service.impl
+
+import org.springframework.stereotype.Service
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.service.EmailAuthenticationService
+
+@Service
+class EmailAuthenticationServiceImpl: EmailAuthenticationService {
+    override fun send(authUserInfo: AuthUserInfo, email: String): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun tokenVerification(email: String): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -1,0 +1,49 @@
+package site.hirecruit.hr.domain.auth.service.impl
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.auth.repository.TempUserRepository
+import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.auth.service.EmailAuthenticationService
+import site.hirecruit.hr.domain.auth.service.UserRegistrationService
+import site.hirecruit.hr.global.event.UserRegistrationEvent
+
+@Service
+class UserRegistrationServiceImpl(
+    private val emailAuthenticationService: EmailAuthenticationService,
+    private val userRepository: UserRepository,
+    private val tempRepository: TempUserRepository,
+    private val publisher: ApplicationEventPublisher
+): UserRegistrationService {
+
+
+    override fun registration(authUserInfo: AuthUserInfo, userRegistrationInfo: UserRegistrationDto): AuthUserInfo {
+        val userEntity = UserEntity(
+            githubId = authUserInfo.githubId,
+            email = userRegistrationInfo.email,
+            name = userRegistrationInfo.name ?: authUserInfo.name,
+            profileImgUri = authUserInfo.profileImgUri,
+            Role.UNAUTHENTICATED_EMAIL
+        )
+        val savedUserEntity = userRepository.save(userEntity)
+
+        emailAuthenticationService.send(authUserInfo, userRegistrationInfo.email) // 비동기 처리 예정
+
+        tempRepository.deleteById(savedUserEntity.githubId) // 임시 유저 제거
+
+        // UserRegistrationEvent발생시킴 이후 타 도메인 로직은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
+        publisher.publishEvent(UserRegistrationEvent(savedUserEntity.githubId, userRegistrationInfo.workerDto))
+        return AuthUserInfo(
+            githubId = savedUserEntity.githubId,
+            name = savedUserEntity.name,
+            email = savedUserEntity.email,
+            profileImgUri = savedUserEntity.profileImgUri,
+            role = savedUserEntity.role
+        )
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -42,7 +42,7 @@ class UserRegistrationServiceImpl(
 
         emailAuthenticationService.send(authUserInfo, userRegistrationInfo.email) // 비동기 처리 예정
 
-        // UserRegistrationEvent발생시킴 이후 타 도메인 로직은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
+        // UserRegistrationEvent발생시킴 이후 타 도메인 로직(ex. workerEntity 생성 등...)은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
         publisher.publishEvent(UserRegistrationEvent(savedUserEntity.githubId, userRegistrationInfo.workerDto))
         return AuthUserInfo(
             githubId = savedUserEntity.githubId,

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -6,21 +6,30 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.auth.entity.UserEntity
-import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.EmailAuthenticationService
 import site.hirecruit.hr.domain.auth.service.UserRegistrationService
 import site.hirecruit.hr.global.event.UserRegistrationEvent
 
+/**
+ * 회원가입을 하는 [UserRegistrationService]의 구현체
+ *
+ * @author 정시원
+ * @since 1.0
+ */
 @Service
 class UserRegistrationServiceImpl(
     private val emailAuthenticationService: EmailAuthenticationService,
     private val userRepository: UserRepository,
-    private val tempRepository: TempUserRepository,
     private val publisher: ApplicationEventPublisher
 ): UserRegistrationService {
 
-
+    /**
+     * 회원가입을 진행하는 메서드 [UserRegistrationEvent]가 발생한다.
+     *
+     * @see site.hirecruit.hr.domain.auth.aop.UserRegistrationAspect
+     * @see UserRegistrationEvent
+     */
     override fun registration(authUserInfo: AuthUserInfo, userRegistrationInfo: UserRegistrationDto): AuthUserInfo {
         val userEntity = UserEntity(
             githubId = authUserInfo.githubId,
@@ -32,8 +41,6 @@ class UserRegistrationServiceImpl(
         val savedUserEntity = userRepository.save(userEntity)
 
         emailAuthenticationService.send(authUserInfo, userRegistrationInfo.email) // 비동기 처리 예정
-
-        tempRepository.deleteById(savedUserEntity.githubId) // 임시 유저 제거
 
         // UserRegistrationEvent발생시킴 이후 타 도메인 로직은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
         publisher.publishEvent(UserRegistrationEvent(savedUserEntity.githubId, userRegistrationInfo.workerDto))

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -2,6 +2,7 @@ package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.auth.entity.Role
@@ -30,6 +31,7 @@ class UserRegistrationServiceImpl(
      * @see site.hirecruit.hr.domain.auth.aop.UserRegistrationAspect
      * @see UserRegistrationEvent
      */
+    @Transactional
     override fun registration(authUserInfo: AuthUserInfo, userRegistrationInfo: UserRegistrationDto): AuthUserInfo {
         val userEntity = UserEntity(
             githubId = authUserInfo.githubId,
@@ -42,7 +44,7 @@ class UserRegistrationServiceImpl(
 
         emailAuthenticationService.send(authUserInfo, userRegistrationInfo.email) // 비동기 처리 예정
 
-        // UserRegistrationEvent발생시킴 이후 타 도메인 로직(ex. workerEntity 생성 등...)은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
+        // UserRegistrationEvent발생시킴. 타 도메인 로직(ex. workerEntity 생성 등...)은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
         publisher.publishEvent(UserRegistrationEvent(savedUserEntity.githubId, userRegistrationInfo.workerDto))
         return AuthUserInfo(
             githubId = savedUserEntity.githubId,

--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -1,0 +1,17 @@
+package site.hirecruit.hr.domain.worker.dto
+
+import javax.validation.constraints.NotBlank
+
+class WorkerDto {
+
+    data class Registration(
+        @field:NotBlank
+        val company: String,
+
+        @field:NotBlank
+        val location: String,
+
+        val introduction: String? = null,
+        val devYear: Int? = null
+    )
+}

--- a/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEvent.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEvent.kt
@@ -1,0 +1,14 @@
+package site.hirecruit.hr.global.event
+
+import site.hirecruit.hr.domain.worker.dto.WorkerDto
+
+/**
+ * 회원이 가입을 시도하면 발생하는 이벤트 객체
+ *
+ * @see site.hirecruit.hr.domain.auth.service.impl.UserRegistrationServiceImpl
+ * @author 정시원
+ */
+class UserRegistrationEvent(
+    private val githubId: Long,
+    private val workerInfo: WorkerDto.Registration
+)

--- a/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEvent.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEvent.kt
@@ -8,7 +8,7 @@ import site.hirecruit.hr.domain.worker.dto.WorkerDto
  * @see site.hirecruit.hr.domain.auth.service.impl.UserRegistrationServiceImpl
  * @author 정시원
  */
-class UserRegistrationEvent(
+data class UserRegistrationEvent(
     private val githubId: Long,
     private val workerInfo: WorkerDto.Registration
 )

--- a/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEventHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEventHandler.kt
@@ -1,0 +1,22 @@
+package site.hirecruit.hr.global.event
+
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * [UserRegistrationEvent]가 발생하면 해당 헨들러에서 처리한다.
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+@Component
+class UserRegistrationEventHandler{
+
+    /**
+     * UserRegistrationEvent가 발생하면 해당 이벤트 객체를 기반으로 Worker를 생성한다.
+     */
+    @EventListener
+    fun createWorker(userRegistrationEvent: UserRegistrationEvent){
+        TODO("WorkerService(가칭)를 통해 UserRegistrationEvent가 발생할 때 worker를 생성할 예정")
+    }
+}

--- a/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEventHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/UserRegistrationEventHandler.kt
@@ -1,7 +1,11 @@
 package site.hirecruit.hr.global.event
 
-import org.springframework.context.event.EventListener
+import mu.KotlinLogging
 import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+private val log = KotlinLogging.logger {}
 
 /**
  * [UserRegistrationEvent]가 발생하면 해당 헨들러에서 처리한다.
@@ -15,8 +19,9 @@ class UserRegistrationEventHandler{
     /**
      * UserRegistrationEvent가 발생하면 해당 이벤트 객체를 기반으로 Worker를 생성한다.
      */
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // event publisher가 commit된 후 해당 event handler가 실행된다.
     fun createWorker(userRegistrationEvent: UserRegistrationEvent){
+        log.debug("UserRegistrationEvent activate UserRegistrationEvent='$userRegistrationEvent'")
         TODO("WorkerService(가칭)를 통해 UserRegistrationEvent가 발생할 때 worker를 생성할 예정")
     }
 }

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
@@ -1,0 +1,5 @@
+package site.hirecruit.hr.domain.auth.service.impl
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class UserRegistrationServiceImplTest

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
@@ -1,5 +1,68 @@
 package site.hirecruit.hr.domain.auth.service.impl
 
+import io.mockk.*
+import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.auth.service.EmailAuthenticationService
+import site.hirecruit.hr.domain.worker.dto.WorkerDto
+import site.hirecruit.hr.global.event.UserRegistrationEvent
+import kotlin.random.Random
 
-internal class UserRegistrationServiceImplTest
+internal class UserRegistrationServiceImplTest{
+
+
+    @Test
+    fun registrationTest(){
+        // Given
+        val emailAuthenticationService: EmailAuthenticationService = spyk()
+        val userRepository: UserRepository = mockk()
+        val publisher: ApplicationEventPublisher = spyk()
+        val userRegistrationServiceImpl = UserRegistrationServiceImpl(emailAuthenticationService, userRepository, publisher)
+
+        val userRegistrationDto = UserRegistrationDto(
+            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            name = RandomString.make(5),
+            workerDto = WorkerDto.Registration(
+                company = RandomString.make(5),
+                location = RandomString.make(5),
+            )
+        )
+        val tempUserAuthUserInfo = AuthUserInfo( // 임시 유저에 대한 인증 객체
+            githubId = Random.nextLong(),
+            name = RandomString.make(5),
+            email = null,
+            profileImgUri = RandomString.make(),
+            Role.GUEST
+        )
+        val userEntity = UserEntity(
+            githubId = tempUserAuthUserInfo.githubId,
+            name = userRegistrationDto.name!!,
+            email = userRegistrationDto.email,
+            profileImgUri = tempUserAuthUserInfo.profileImgUri,
+            role = Role.UNAUTHENTICATED_EMAIL
+        )
+
+        /**
+         * User를 저장하는 UserRepository 이외에는 메서드에 대한 리턴값이 필요하지 않다.
+         */
+        every { userRepository.save(userEntity) } answers {userEntity}
+
+        // when
+        val authUserInfo = userRegistrationServiceImpl.registration(tempUserAuthUserInfo, userRegistrationDto)
+
+        //then
+        verify(exactly = 1) {userRepository.save(userEntity)}
+        verify(exactly = 1) {emailAuthenticationService.send(tempUserAuthUserInfo, userRegistrationDto.email)}
+        val userRegistrationEvent = UserRegistrationEvent(tempUserAuthUserInfo.githubId, userRegistrationDto.workerDto)
+        verify(exactly = 1) {publisher.publishEvent(userRegistrationEvent)}
+
+        assertNotEquals(tempUserAuthUserInfo, authUserInfo) // 회원가입한 유저의 정보와 임시 유저일 떄의 정보는 다르다.
+    }
+}

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
@@ -3,6 +3,7 @@ package site.hirecruit.hr.domain.auth.service.impl
 import io.mockk.*
 import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
@@ -17,13 +18,14 @@ import kotlin.random.Random
 
 internal class UserRegistrationServiceImplTest{
 
+    private val emailAuthenticationService: EmailAuthenticationService = spyk()
+    private val publisher: ApplicationEventPublisher = spyk()
 
-    @Test
+    @Test @DisplayName("유저 회원가입 로직(UserRegistrationService.registration(...)) 테스트")
     fun registrationTest(){
         // Given
-        val emailAuthenticationService: EmailAuthenticationService = spyk()
         val userRepository: UserRepository = mockk()
-        val publisher: ApplicationEventPublisher = spyk()
+
         val userRegistrationServiceImpl = UserRegistrationServiceImpl(emailAuthenticationService, userRepository, publisher)
 
         val userRegistrationDto = UserRegistrationDto(
@@ -50,12 +52,12 @@ internal class UserRegistrationServiceImplTest{
         )
 
         /**
-         * User를 저장하는 UserRepository 이외에는 메서드에 대한 리턴값이 필요하지 않다.
+         * User를 저장하는 UserRepository 이외에는 메서드에 대한 리턴값이 비즈니스 로직에 영향을 미치지 않는다.
          */
         every { userRepository.save(userEntity) } answers {userEntity}
 
         // when
-        val authUserInfo = userRegistrationServiceImpl.registration(tempUserAuthUserInfo, userRegistrationDto)
+        val registeredAuthUserInfo = userRegistrationServiceImpl.registration(tempUserAuthUserInfo, userRegistrationDto)
 
         //then
         verify(exactly = 1) {userRepository.save(userEntity)}
@@ -63,6 +65,67 @@ internal class UserRegistrationServiceImplTest{
         val userRegistrationEvent = UserRegistrationEvent(tempUserAuthUserInfo.githubId, userRegistrationDto.workerDto)
         verify(exactly = 1) {publisher.publishEvent(userRegistrationEvent)}
 
-        assertNotEquals(tempUserAuthUserInfo, authUserInfo) // 회원가입한 유저의 정보와 임시 유저일 떄의 정보는 다르다.
+        // 임시 유저일 떄의 Role과 registration()를 수행한 유저일 때의 Role은 다르다.
+        assertAll({
+            assertNotEquals(tempUserAuthUserInfo.role, registeredAuthUserInfo.role)
+            assertEquals(Role.UNAUTHENTICATED_EMAIL, registeredAuthUserInfo.role)
+        })
+
+        // 임시 유저일 때 githubId와 profileImgUri는 registration()을 수행한 후도 같다.
+        assertAll({
+            assertEquals(tempUserAuthUserInfo.githubId, registeredAuthUserInfo.githubId)
+            assertEquals(tempUserAuthUserInfo.profileImgUri, registeredAuthUserInfo.profileImgUri)
+        })
+
+        // UserRegistrationDto의 email과 name은 registeredAuthUserInfo와 같다.
+        // 만약 name이 null이라면 임시 유저일 떄 name이 기본값이다. 밑에 있는 'registration로직에서_UserRegistrationDtoName이NULL이라면()' 참고
+        assertAll({
+            assertEquals(userRegistrationDto.email, registeredAuthUserInfo.email)
+            assertEquals(userRegistrationDto.name, registeredAuthUserInfo.name)
+        })
     }
+
+    @Test @DisplayName("유저 회원가입 로직(UserRegistrationService.registration(...))에서 UserRegistrationDto.name이 null이라면?")
+    fun registration로직에서_UserRegistrationDtoName이NULL이라면(){
+        // Given
+        val userRepository: UserRepository = mockk()
+
+        val userRegistrationServiceImpl = UserRegistrationServiceImpl(emailAuthenticationService, userRepository, publisher)
+
+        val userRegistrationDto = UserRegistrationDto(
+            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            name = null,    // UserRegistrationDto.email = null
+            workerDto = WorkerDto.Registration(
+                company = RandomString.make(5),
+                location = RandomString.make(5),
+            )
+        )
+        val tempUserAuthUserInfo = AuthUserInfo( // 임시 유저에 대한 인증 객체
+            githubId = Random.nextLong(),
+            name = RandomString.make(5),
+            email = null,
+            profileImgUri = RandomString.make(),
+            Role.GUEST
+        )
+        val userEntity = UserEntity(
+            githubId = tempUserAuthUserInfo.githubId,
+            name = tempUserAuthUserInfo.name, // 임시 유저가 가지고 있는 name
+            email = userRegistrationDto.email,
+            profileImgUri = tempUserAuthUserInfo.profileImgUri,
+            role = Role.UNAUTHENTICATED_EMAIL
+        )
+
+        /**
+         * User를 저장하는 UserRepository 이외에는 메서드에 대한 리턴값이 비즈니스 로직에 영향을 미치지 않는다.
+         */
+        every { userRepository.save(userEntity) } answers {userEntity}
+
+        // when
+        val registeredAuthUserInfo = userRegistrationServiceImpl.registration(tempUserAuthUserInfo, userRegistrationDto)
+
+        // then
+        verify(exactly = 1) {userRepository.save(userEntity)}
+        assertEquals(tempUserAuthUserInfo.name, registeredAuthUserInfo.name)
+    }
+
 }


### PR DESCRIPTION
## 개요
회원가입 로직(`UserRegistrationService.registration(...)`)을 완료했습니다.

추가적으로 이메일 인증 관련된 serivce의 interface(`EmailAuthenticationService`)를 작성했습니다.

#### API 명세서
<img width="662" alt="CleanShot 2022-05-22 at 19 08 02@2x" src="https://user-images.githubusercontent.com/62932968/169690263-e31ba45f-69c2-4272-a1dd-1d8595dbe46e.png">

## 로직 설명
1. 임시 유저의 인증정보(`tempUserAuthInfo`)와 유저가 입력한 `RegistrationDto`의 정보를 기반으로 회원을 save합니다.
2. 그 후 email 인증을 위해 회원에게 email인증 메일을 전송합니다. (구현예정)
3. `UserRegistrationEvent`를 발행합니다.
4. AOP(`UserRegistrationAspect`)를 통해 session에 저장되어 있는 `AuthUserInfo`에 있는 정보를 업데이트 하고, 임시유저(`TempUser`)를 제거합니다.

#### `UserRegistrationEvent`를 발행하는 이유
회원가입 후 직장인(Worker)을 생성해야 하는 비즈니스 요구사항으로 인해 
**Auth도메인과, Worker도메인의 강한 결합을 `Event-Driven`한 방식을 통해 해결하고 싶었습니다.** 

## 기타 변경사항
- `org.aspectj.lang.annotation.Aspect` annotation을 사용한 class는 allOpen하도록 했습니다.

## next todo list
1. AOP class unit test
   > 변경된 파일이 많아진 관계로 해당 PR에서 test코드를 작성하는 것이 아닌 나눠서 다음PR에서 작성하겠습니다.
2. Worker생성, 수정 등... Worker 도메인에 관련된 로직 작성
3. 이메일 인증 로직 작성
   > @jyeonjyan 님이 담당하신 email sender logic feature 완료 후 개발할 예정입니다.

