### PR TITLE
Feature/aws sns sub email

### DIFF
--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSnsConfig.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSnsConfig.kt
@@ -1,10 +1,13 @@
 package site.hirecruit.hr.thirdParty.aws.config
 
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.PropertySource
-import site.hirecruit.hr.domain.auth.aop.log
 import javax.annotation.PostConstruct
+
+
+private val log = KotlinLogging.logger {}
 
 /**
  * 인스턴스 생성 시점에 aws env 설정이 대입되어 초기화 된다.

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/ProtocolType.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/ProtocolType.kt
@@ -1,0 +1,5 @@
+package site.hirecruit.hr.thirdParty.aws.sns
+
+enum class ProtocolType {
+    EMAIL,
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryService.kt
@@ -6,4 +6,5 @@ import software.amazon.awssdk.services.sns.model.Topic
 interface SnsTopicFactoryService {
     fun createTopic(topicName: String) : CreateTopicResponse
     fun displayAllTopics() : MutableList<Topic>
+    fun subTopicByEmail(email: String, topicArn: String) : String
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -55,6 +55,8 @@ class SnsTopicFactoryServiceImpl(
      *
      * @param email 등록하고자 하는 email
      * @param topicArn 대상 topicArn
+     * @see SnsTopicSubSystemFacade.subscribeEmail 값을 최종적으로 리턴 함.
+     * @return subscriptionArn - 구독을 식별할 수 있는 subscriptionArn
      */
     override fun subTopicByEmail(email: String, topicArn: String): String {
         val subscribeRequest = snsTopicSubSystemFacade.createSubscribeRequest(email, topicArn)

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -52,6 +52,9 @@ class SnsTopicFactoryServiceImpl(
 
     /**
      * email 주소로 amazon sns topic 구독
+     *
+     * @param email 등록하고자 하는 email
+     * @param topicArn 대상 topicArn
      */
     override fun subTopicByEmail(email: String, topicArn: String): String {
         val subscribeRequest = snsTopicSubSystemFacade.createSubscribeRequest(email, topicArn)

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -50,4 +50,13 @@ class SnsTopicFactoryServiceImpl(
             ?: throw NoSuchElementException("요청하신 getAllTopics의 결과: topics element가 존재하지 않습니다.")
     }
 
+    /**
+     * email 주소로 amazon sns topic 구독
+     */
+    override fun subTopicByEmail(email: String, topicArn: String): String {
+        val subscribeRequest = snsTopicSubSystemFacade.createSubscribeRequest(email, topicArn)
+
+        return snsTopicSubSystemFacade.subscribeEmail(subscribeRequest, credentialService.getSnsClient())
+    }
+
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -1,12 +1,14 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service.facade
 
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import site.hirecruit.hr.thirdParty.aws.sns.ProtocolType
 import software.amazon.awssdk.http.SdkHttpResponse
 import software.amazon.awssdk.services.sns.SnsClient
-import software.amazon.awssdk.services.sns.model.CreateTopicRequest
-import software.amazon.awssdk.services.sns.model.CreateTopicResponse
-import software.amazon.awssdk.services.sns.model.ListTopicsRequest
-import software.amazon.awssdk.services.sns.model.ListTopicsResponse
+import software.amazon.awssdk.services.sns.model.*
+
+
+private val log = KotlinLogging.logger {}
 
 /**
  * service layer -> facade layer -> sdk
@@ -73,6 +75,46 @@ class SnsTopicSubSystemFacade {
     }
 
     /**
+     * SubscribeRequest를 만들어주는 로직
+     *
+     * @param targetEmail 등록하고자 하는 email
+     * @param targetTopicArn email 등록 대상 topicArn
+     */
+    fun createSubscribeRequest(targetEmail: String, targetTopicArn: String) : SubscribeRequest{
+
+        isTargetTopicArnExist(targetTopicArn)
+
+        return SubscribeRequest.builder()
+            .protocol(ProtocolType.EMAIL.toString().lowercase()) // "email" 이라는 sdk prefix 를 사용해야 함.
+            .endpoint(targetEmail)
+            .returnSubscriptionArn(true)
+            .topicArn(targetTopicArn)
+            .build()
+    }
+
+    /**
+     * snsClient가 개입하여 실제 topic에 email을 sub 하는 로직
+     *
+     * @param subscribeRequest createSubscribeRequest() 결과
+     * @param snsClient 인증된 sns 클라이언트
+     */
+    fun subscribeEmail(
+        subscribeRequest: SubscribeRequest,
+        snsClient: SnsClient
+    ) : String{
+
+        val subscribeResponse = snsClient.subscribe(subscribeRequest)
+        isSdkHttpResponseIsSuccessful(subscribeResponse.sdkHttpResponse())
+
+        log.info {
+            "Subscription ARN: ${subscribeResponse.subscriptionArn()} " +
+                    "===== status: ${subscribeResponse.sdkHttpResponse().statusCode()}"
+        }
+
+        return subscribeResponse.subscriptionArn()
+    }
+
+    /**
      * sdkHttpResponse가 !isOk 대해 Exception을 발생시켜주는 HealthChecker
      *
      * @param sdkHttpResponse snsClient 결과 sdkHttpResponse
@@ -83,5 +125,9 @@ class SnsTopicSubSystemFacade {
         if (!sdkHttpResponse.isSuccessful) {
             throw Exception("sdkHttpResponse가 기대값 isSuccessful를 만족시키지 못 함 ======== code: ${sdkHttpResponse.statusCode()}  msg: ${sdkHttpResponse.statusText()}")
         }
+    }
+
+    private fun isTargetTopicArnExist(targetTopicArn: String) {
+        TODO("Not yet implemented")
     }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -95,6 +95,7 @@ class SnsTopicSubSystemFacade {
      *
      * @param subscribeRequest createSubscribeRequest() 결과
      * @param snsClient 인증된 sns 클라이언트
+     * @return subscriptionArn - 구독을 식별할 수 있는 subscriptionArn
      */
     fun subscribeEmail(
         subscribeRequest: SubscribeRequest,

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/facade/SnsTopicSubSystemFacade.kt
@@ -82,8 +82,6 @@ class SnsTopicSubSystemFacade {
      */
     fun createSubscribeRequest(targetEmail: String, targetTopicArn: String) : SubscribeRequest{
 
-        isTargetTopicArnExist(targetTopicArn)
-
         return SubscribeRequest.builder()
             .protocol(ProtocolType.EMAIL.toString().lowercase()) // "email" 이라는 sdk prefix 를 사용해야 함.
             .endpoint(targetEmail)
@@ -127,7 +125,4 @@ class SnsTopicSubSystemFacade {
         }
     }
 
-    private fun isTargetTopicArnExist(targetTopicArn: String) {
-        TODO("Not yet implemented")
-    }
 }

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import site.hirecruit.hr.domain.test_util.LocalTest
@@ -69,5 +70,29 @@ class SnsTopicFactoryServiceImplTest{
         // Then
         verify(exactly = 1) { snsTopicSubSystemFacade.createListTopicRequest() }
         verify(exactly = 1) { credentialService.getSnsClient() }
+    }
+
+    @Test
+    @DisplayName("topicArn에 알맞는 topic에 email이 정상적으로 등록된다")
+    fun subEmailToTopicArnSuccessful(){
+        // Given:: mocking
+        val snsClient : SnsClient = mockk()
+        val credentialService : CredentialService = mockk()
+        val snsTopicSubSystemFacade : SnsTopicSubSystemFacade = mockk()
+        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(credentialService, snsTopicSubSystemFacade)
+
+        // Given:: stubs
+        every { snsTopicSubSystemFacade.createSubscribeRequest(any(), any()) }.returns(any())
+        every { credentialService.getSnsClient() }.returns(snsClient)
+        every { snsTopicSubSystemFacade.subscribeEmail(any(), snsClient) }.returns(any())
+
+        // When
+        assertDoesNotThrow {
+            snsTopicFactoryService.subTopicByEmail(RandomString.make(5), RandomString.make(5))
+        }
+
+        // Then
+        verify(exactly = 1) { snsTopicSubSystemFacade.createSubscribeRequest(any(), any()) }
+        verify(exactly = 1) { snsTopicSubSystemFacade.subscribeEmail(any(), any()) }
     }
 }


### PR DESCRIPTION
### 개요
`protocol: email` 에 대해 email을 topic에 sub 할 수 있는 로직 구현

### 앞으로 해야할 일
* 구독 -> "엔드포인트 sns 수신 허용" 했는지 확인하는 로직 개발 (1)
* topic send 로직 개발 (2)
* topic send 대기열 queue 개발 (3)