### PR TITLE
Auth Aspect classes test code

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspect.kt
@@ -19,7 +19,7 @@ private val log = KotlinLogging.logger {}
  */
 @Component
 @Aspect
-private class UserAuthAspect (
+class UserAuthAspect (
     private val httpSession: HttpSession
 ) {
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspect.kt
@@ -21,7 +21,7 @@ private val log = KotlinLogging.logger {}
  */
 @Component
 @Aspect
-private class UserRegistrationAspect(
+class UserRegistrationAspect(
     private val tempUserRepository: TempUserRepository,
     private val httpSession: HttpSession
 ) {

--- a/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
@@ -23,10 +23,10 @@ class AuthController(
 
         @RequestBody  @Valid
         userRegistrationDto: UserRegistrationDto
-    ): ResponseEntity<Map<String, Long>>{
+    ): ResponseEntity<AuthUserInfo>{
         val registeredAuthUserInfo = userRegistrationService.registration(authUserInfo, userRegistrationDto)
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(mapOf("githubId" to registeredAuthUserInfo.githubId))
+            .body(registeredAuthUserInfo)
     }
 
 }

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserAuthAspectTest.kt
@@ -1,0 +1,62 @@
+package site.hirecruit.hr.domain.auth.aop
+
+import io.mockk.every
+import io.mockk.mockk
+import net.bytebuddy.utility.RandomString
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
+import org.springframework.mock.web.MockHttpSession
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.service.UserAuthService
+import site.hirecruit.hr.global.data.SessionAttribute
+import kotlin.random.Random
+
+internal class UserAuthAspectTest{
+
+    private fun makeOAuth2Attributes() : OAuthAttributes {
+        val attributes = mapOf<String, Any>(
+            "id" to Random.nextInt(8),
+            "name" to RandomString.make(8),
+            "email" to "${RandomString.make(10)}${RandomString.make(6)}.${RandomString.make(3)}}",
+            "avatar_url" to RandomString.make()
+        )
+        return OAuthAttributes.of(
+            registrationId = "github",
+            userNameAttributeName = "id",
+            attributes = attributes
+        )
+    }
+
+    @Test @DisplayName("proxy.authentication를 실행 후 UserAuthAspect가 Session에 반환값을 잘 실행하는지")
+    fun userAuthAspectTest(){
+        // Given
+        val httpSession = MockHttpSession()
+
+        val oAuth2Attributes = makeOAuth2Attributes()
+        val proxyReturnValue = AuthUserInfo(
+            githubId = oAuth2Attributes.id,
+            email = null,
+            name = oAuth2Attributes.name,
+            profileImgUri = oAuth2Attributes.profileImgUri,
+            role = Role.GUEST
+        )
+
+        val userAuthService: UserAuthService = mockk() // proxy
+        val factory = AspectJProxyFactory(userAuthService)
+        every { userAuthService.authentication(oAuth2Attributes) } answers { proxyReturnValue }
+        factory.addAspect(UserAuthAspect(httpSession))
+        val proxy = factory.getProxy<UserAuthService>()
+
+        // when
+        proxy.authentication(oAuth2Attributes)
+
+        // then
+        val sessionAuthUserInfo = httpSession.getAttribute(SessionAttribute.AUTH_USER_INFO.attributeName)
+        Assertions.assertEquals(proxyReturnValue, sessionAuthUserInfo)
+    }
+}

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
@@ -1,0 +1,86 @@
+package site.hirecruit.hr.domain.auth.aop
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import net.bytebuddy.utility.RandomString
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
+import org.springframework.mock.web.MockHttpSession
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.repository.TempUserRepository
+import site.hirecruit.hr.domain.auth.service.UserRegistrationService
+import site.hirecruit.hr.domain.test_util.LocalTest
+import site.hirecruit.hr.domain.worker.dto.WorkerDto
+import site.hirecruit.hr.global.data.SessionAttribute
+import kotlin.random.Random
+
+@LocalTest
+internal class UserRegistrationAspectTest{
+
+    private lateinit var httpSession: MockHttpSession;
+    private lateinit var tempUserInfo: AuthUserInfo;
+
+    @BeforeEach
+    fun beforeRegistrationInSession(){
+        httpSession = MockHttpSession()
+        tempUserInfo = AuthUserInfo(
+            githubId = Random.nextLong(),
+            name = RandomString.make(5),
+            email = null,
+            profileImgUri = RandomString.make(15),
+            role = Role.GUEST
+        )
+        httpSession.setAttribute(SessionAttribute.AUTH_USER_INFO.attributeName, tempUserInfo)
+    }
+
+    @Test @DisplayName("afterRegistrationMethod test")
+    fun afterRegistrationMethodTest(){
+        // given
+
+        // given:: Aspect가 실행될 proxy
+        val userRegistrationService: UserRegistrationService = mockk()
+
+        // given:: Aspect가 실행될 proxy
+        val tempUserRepository: TempUserRepository = spyk()
+
+        // given:: UserRegistrationService에 Aspect추가 및 proxy 가져오기
+        val factory = AspectJProxyFactory(userRegistrationService)
+        factory.addAspect(UserRegistrationAspect(tempUserRepository, httpSession))
+        val proxy = factory.getProxy<UserRegistrationService>()
+
+        // given:: Aspect가 실행될 proxy
+        val userRegistrationDto = UserRegistrationDto(
+            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            name = RandomString.make(5),
+            workerDto = WorkerDto.Registration(
+                company = RandomString.make(8),
+                location = RandomString.make(8)
+            )
+        )
+        val proxyReturnValue = AuthUserInfo(
+            githubId = tempUserInfo.githubId,
+            name = userRegistrationDto.name!!,
+            email = userRegistrationDto.email,
+            profileImgUri = tempUserInfo.profileImgUri,
+            role = Role.UNAUTHENTICATED_EMAIL
+        )
+
+        // proxy(userRegistrationService) 객체는 proxyReturnValue를 반환한다.
+        every { userRegistrationService.registration(tempUserInfo, userRegistrationDto) } answers { proxyReturnValue }
+
+        // when AOP에 사용된 proxy 객체의 AOP가 적용된 메서드를 실행한다.
+        proxy.registration(tempUserInfo, userRegistrationDto)
+
+        // then
+        verify(exactly = 1) { tempUserRepository.deleteById(tempUserInfo.githubId) }
+        val sessionAuthUserInfo = httpSession.getAttribute(SessionAttribute.AUTH_USER_INFO.attributeName) as AuthUserInfo
+        Assertions.assertEquals(proxyReturnValue, sessionAuthUserInfo, "proxy가 반환한 정보가 session에 반환되지 않았으므로 Aspect setSession로직 확인 요망")
+    }
+}


### PR DESCRIPTION
## 개요
Auth 도메인의 Aspect 클래스들에 대한 test code를 작성했습니다.

![CleanShot 2022-05-24 at 12 07 21](https://user-images.githubusercontent.com/62932968/169940802-99525579-5ee1-4e30-a06c-a996def03ba5.png)


### 추가 변경사항 
#49 에서 registration api에 DTO를 반환하는게 좋을 거 같다는 의견을 반영했습니다.


## Next TODO
- `UserRegistrationService` 이메일 인증 없는 클래스 구현
- Worker 도메인 CRUD