### PR TITLE
Hotfix/aws sns config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,9 @@ dependencies {
     implementation("com.amazonaws:aws-java-sdk-core:1.12.223")
     // software.amazon.awssdk/sns
     implementation("software.amazon.awssdk:sns:2.17.193")
+    // software.amazon.awssdk/ses
+    implementation("software.amazon.awssdk:ses:2.17.198")
+
 
 
     /** for test **/

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSesConfig.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSesConfig.kt
@@ -1,0 +1,10 @@
+package site.hirecruit.hr.thirdParty.aws.config
+
+/**
+ * aws ses service 를 쓰기위한 설정 정보들이 init 됩니다.
+ *
+ * @author 전지환
+ * @since 1.0.0
+ */
+class AwsSesConfig {
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSesConfig.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSesConfig.kt
@@ -1,10 +1,39 @@
 package site.hirecruit.hr.thirdParty.aws.config
 
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.PropertySource
+import javax.annotation.PostConstruct
+
+
+private val log = KotlinLogging.logger {}
+
 /**
  * aws ses service 를 쓰기위한 설정 정보들이 init 됩니다.
  *
  * @author 전지환
  * @since 1.0.0
  */
-class AwsSesConfig {
+@Configuration
+@PropertySource("classpath:/aws/aws-ses-config.properties")
+class AwsSesConfig(
+    @Value("\${aws.accessKey}")
+    val awsAccessKey: String,
+
+    @Value("\${aws.secretKey}")
+    val awsSecretKey: String,
+
+    @Value("\${aws.region}")
+    val awsRegion: String
+){
+
+    @PostConstruct
+    fun init() {
+        log.debug { "AwsSnsConfig(" +
+                "awsAccessKey='$awsAccessKey', " +
+                "awsSecretKey='$awsSecretKey', " +
+                "awsRegion='$awsRegion'" +
+                ")" }
+    }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSnsConfig.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/config/AwsSnsConfig.kt
@@ -19,9 +19,6 @@ private val log = KotlinLogging.logger {}
 @PropertySource("classpath:/aws/aws-sns-config.properties")
 class AwsSnsConfig(
 
-    @Value("\${sns.topic.arn}")
-    val snsTopicARN: String,
-
     @Value("\${aws.accessKey}")
     val awsAccessKey: String,
 
@@ -36,7 +33,6 @@ class AwsSnsConfig(
     @PostConstruct
     fun init() {
         log.debug { "AwsSnsConfig(" +
-                "snsTopicARN='$snsTopicARN', " +
                 "awsAccessKey='$awsAccessKey', " +
                 "awsSecretKey='$awsSecretKey', " +
                 "awsRegion='$awsRegion'" +

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
@@ -1,0 +1,9 @@
+package site.hirecruit.hr.thirdParty.aws.service
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.core.SdkClient
+
+interface CredentialService {
+    fun getSdkClient(): SdkClient
+    fun getAwsCredentials(accessKey: String, secretKey: String) : AwsCredentialsProvider
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/CredentialService.kt
@@ -1,9 +1,21 @@
 package site.hirecruit.hr.thirdParty.aws.service
 
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.core.SdkClient
 
 interface CredentialService {
     fun getSdkClient(): SdkClient
-    fun getAwsCredentials(accessKey: String, secretKey: String) : AwsCredentialsProvider
+
+    /**
+     * accessKey, secretKey 로 해당 IAM 의 자격을 얻는다.
+     * default method로써 재정의를 강제하지 않는다.
+     *
+     * @see getSdkClient - credentials가 필요한 부분에 넣어준다.
+     */
+    fun getAwsCredentials(accessKey: String, secretKey: String) : AwsCredentialsProvider {
+        return AwsCredentialsProvider {
+            AwsBasicCredentials.create(accessKey, secretKey)
+        }
+    }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SesCredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SesCredentialService.kt
@@ -1,0 +1,33 @@
+package site.hirecruit.hr.thirdParty.aws.service
+
+import org.springframework.stereotype.Service
+import site.hirecruit.hr.thirdParty.aws.config.AwsSesConfig
+import software.amazon.awssdk.core.SdkClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ses.SesClient
+
+/**
+ * Aws Ses IAM 을 관리하는 서비스 객체 입니다.
+ *
+ * @author 전지환
+ * @since 1.0.0
+ */
+@Service
+class SesCredentialService(
+    private val awsSesConfig: AwsSesConfig
+) : CredentialService {
+
+    /**
+     * aws ses 서비스를 사용할 수 있는 sdk 를 제공한다.
+     *
+     * @see AwsSesConfig ses IAM에 접근할 수 있는 설정
+     */
+    override fun getSdkClient(): SdkClient {
+
+        return SesClient.builder()
+            .credentialsProvider(
+                getAwsCredentials(awsSesConfig.awsAccessKey, awsSesConfig.awsSecretKey)
+            ).region(Region.of(awsSesConfig.awsRegion))
+            .build()
+    }
+}

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SnsCredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SnsCredentialService.kt
@@ -2,8 +2,6 @@ package site.hirecruit.hr.thirdParty.aws.service
 
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.thirdParty.aws.config.AwsSnsConfig
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sns.SnsClient
 
@@ -30,14 +28,4 @@ class SnsCredentialService(private val awsSnsConfig: AwsSnsConfig) : CredentialS
             .build()
     }
 
-    /**
-     * accessKey, secretKey 로 해당 IAM 의 자격을 얻는다.
-     *
-     * @see getSdkClient - credentials가 필요한 부분에 넣어준다.
-     */
-    override fun getAwsCredentials(accessKey: String, secretKey: String): AwsCredentialsProvider {
-        return AwsCredentialsProvider {
-            AwsBasicCredentials.create(accessKey, secretKey)
-        }
-    }
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SnsCredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SnsCredentialService.kt
@@ -14,14 +14,14 @@ import software.amazon.awssdk.services.sns.SnsClient
  * @author 전지환
  */
 @Service
-class SnsCredentialService(private val awsSnsConfig: AwsSnsConfig) {
+class SnsCredentialService(private val awsSnsConfig: AwsSnsConfig) : CredentialService{
 
     /**
      * aws sns 서비스의 permission이 있는 IAM의 자격을 얻어 properties에 알맞는 region으로 SnsClient를 제공해준다.
      *
      * @see AwsSnsConfig sns전용 IAM에 대한 설정
      */
-    fun getSnsClient(): SnsClient {
+    override fun getSdkClient(): SnsClient {
 
         return SnsClient.builder()
             .credentialsProvider(
@@ -33,9 +33,9 @@ class SnsCredentialService(private val awsSnsConfig: AwsSnsConfig) {
     /**
      * accessKey, secretKey 로 해당 IAM 의 자격을 얻는다.
      *
-     * @see getSnsClient - credentials가 필요한 부분에 넣어준다.
+     * @see getSdkClient - credentials가 필요한 부분에 넣어준다.
      */
-    private fun getAwsCredentials(accessKey: String, secretKey: String): AwsCredentialsProvider {
+    override fun getAwsCredentials(accessKey: String, secretKey: String): AwsCredentialsProvider {
         return AwsCredentialsProvider {
             AwsBasicCredentials.create(accessKey, secretKey)
         }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SnsCredentialService.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/service/SnsCredentialService.kt
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.sns.SnsClient
  * @author 전지환
  */
 @Service
-class CredentialService(private val awsSnsConfig: AwsSnsConfig) {
+class SnsCredentialService(private val awsSnsConfig: AwsSnsConfig) {
 
     /**
      * aws sns 서비스의 permission이 있는 IAM의 자격을 얻어 properties에 알맞는 region으로 SnsClient를 제공해준다.

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -1,9 +1,10 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
 import org.springframework.stereotype.Service
-import site.hirecruit.hr.thirdParty.aws.service.SnsCredentialService
+import site.hirecruit.hr.thirdParty.aws.service.CredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsClientSubSystemFacade
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsRequestSubSystemFacade
+import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
 import software.amazon.awssdk.services.sns.model.CreateTopicResponse
 import software.amazon.awssdk.services.sns.model.Topic
@@ -16,7 +17,7 @@ import software.amazon.awssdk.services.sns.model.Topic
  */
 @Service
 class SnsTopicFactoryServiceImpl(
-    private val snsCredentialService: SnsCredentialService,
+    private val snsCredentialService: CredentialService,
     private val snsRequestSubSystemFacade: SnsRequestSubSystemFacade,
     private val snsClientSubSystemFacade: SnsClientSubSystemFacade
 ) : SnsTopicFactoryService {
@@ -34,9 +35,10 @@ class SnsTopicFactoryServiceImpl(
         val topicRequest = snsRequestSubSystemFacade.createTopicRequest(topicName)
 
         // topicRequest를 aws-sns-api가 처리하도록 serving 함.
-        return snsClientSubSystemFacade.createTopic(topicRequest, snsCredentialService.getSnsClient())
-            ?: throw NoSuchElementException("요청하신 createTopic 결과: CreateTopicResponse가 존재하지 않습니다.")
-
+        return snsClientSubSystemFacade.createTopic(
+            topicRequest,
+            snsCredentialService.getSdkClient() as SnsClient
+        ) ?: throw NoSuchElementException("요청하신 createTopic 결과: CreateTopicResponse가 존재하지 않습니다.")
     }
 
     /**
@@ -48,8 +50,10 @@ class SnsTopicFactoryServiceImpl(
     override fun displayAllTopics() : MutableList<Topic> {
         val listTopicRequest = snsRequestSubSystemFacade.createListTopicRequest()
 
-        return snsClientSubSystemFacade.getAllTopicsAsList(listTopicRequest, snsCredentialService.getSnsClient())?.topics()
-            ?: throw NoSuchElementException("요청하신 getAllTopics의 결과: topics element가 존재하지 않습니다.")
+        return snsClientSubSystemFacade.getAllTopicsAsList(
+            listTopicRequest,
+            snsCredentialService.getSdkClient() as SnsClient
+        )?.topics() ?: throw NoSuchElementException("요청하신 getAllTopics의 결과: topics element가 존재하지 않습니다.")
     }
 
     /**
@@ -63,7 +67,9 @@ class SnsTopicFactoryServiceImpl(
     override fun subTopicByEmail(email: String, topicArn: String): String {
         val subscribeRequest = snsRequestSubSystemFacade.createSubscribeRequest(email, topicArn)
 
-        return snsClientSubSystemFacade.subscribeEmail(subscribeRequest, snsCredentialService.getSnsClient())
+        return snsClientSubSystemFacade.subscribeEmail(subscribeRequest,
+            snsCredentialService.getSdkClient() as SnsClient
+        )
     }
 
     /**
@@ -77,7 +83,9 @@ class SnsTopicFactoryServiceImpl(
         val confirmSubscriptionRequest =
             snsRequestSubSystemFacade.createConfirmSubscriptionRequest(subscriptionToken, topicArn)
 
-        return snsClientSubSystemFacade.isAlreadyConfirm(confirmSubscriptionRequest, snsCredentialService.getSnsClient())
+        return snsClientSubSystemFacade.isAlreadyConfirm(confirmSubscriptionRequest,
+            snsCredentialService.getSdkClient() as SnsClient
+        )
     }
 
 }

--- a/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImpl.kt
@@ -1,7 +1,7 @@
 package site.hirecruit.hr.thirdParty.aws.sns.service
 
 import org.springframework.stereotype.Service
-import site.hirecruit.hr.thirdParty.aws.service.CredentialService
+import site.hirecruit.hr.thirdParty.aws.service.SnsCredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsClientSubSystemFacade
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsRequestSubSystemFacade
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest
@@ -16,7 +16,7 @@ import software.amazon.awssdk.services.sns.model.Topic
  */
 @Service
 class SnsTopicFactoryServiceImpl(
-    private val credentialService: CredentialService,
+    private val snsCredentialService: SnsCredentialService,
     private val snsRequestSubSystemFacade: SnsRequestSubSystemFacade,
     private val snsClientSubSystemFacade: SnsClientSubSystemFacade
 ) : SnsTopicFactoryService {
@@ -34,7 +34,7 @@ class SnsTopicFactoryServiceImpl(
         val topicRequest = snsRequestSubSystemFacade.createTopicRequest(topicName)
 
         // topicRequest를 aws-sns-api가 처리하도록 serving 함.
-        return snsClientSubSystemFacade.createTopic(topicRequest, credentialService.getSnsClient())
+        return snsClientSubSystemFacade.createTopic(topicRequest, snsCredentialService.getSnsClient())
             ?: throw NoSuchElementException("요청하신 createTopic 결과: CreateTopicResponse가 존재하지 않습니다.")
 
     }
@@ -48,7 +48,7 @@ class SnsTopicFactoryServiceImpl(
     override fun displayAllTopics() : MutableList<Topic> {
         val listTopicRequest = snsRequestSubSystemFacade.createListTopicRequest()
 
-        return snsClientSubSystemFacade.getAllTopicsAsList(listTopicRequest, credentialService.getSnsClient())?.topics()
+        return snsClientSubSystemFacade.getAllTopicsAsList(listTopicRequest, snsCredentialService.getSnsClient())?.topics()
             ?: throw NoSuchElementException("요청하신 getAllTopics의 결과: topics element가 존재하지 않습니다.")
     }
 
@@ -63,7 +63,7 @@ class SnsTopicFactoryServiceImpl(
     override fun subTopicByEmail(email: String, topicArn: String): String {
         val subscribeRequest = snsRequestSubSystemFacade.createSubscribeRequest(email, topicArn)
 
-        return snsClientSubSystemFacade.subscribeEmail(subscribeRequest, credentialService.getSnsClient())
+        return snsClientSubSystemFacade.subscribeEmail(subscribeRequest, snsCredentialService.getSnsClient())
     }
 
     /**
@@ -77,7 +77,7 @@ class SnsTopicFactoryServiceImpl(
         val confirmSubscriptionRequest =
             snsRequestSubSystemFacade.createConfirmSubscriptionRequest(subscriptionToken, topicArn)
 
-        return snsClientSubSystemFacade.isAlreadyConfirm(confirmSubscriptionRequest, credentialService.getSnsClient())
+        return snsClientSubSystemFacade.isAlreadyConfirm(confirmSubscriptionRequest, snsCredentialService.getSnsClient())
     }
 
 }

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import site.hirecruit.hr.domain.test_util.LocalTest
-import site.hirecruit.hr.thirdParty.aws.service.SnsCredentialService
+import site.hirecruit.hr.thirdParty.aws.service.CredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsClientSubSystemFacade
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsRequestSubSystemFacade
 import software.amazon.awssdk.services.sns.SnsClient
@@ -24,7 +24,7 @@ class SnsTopicFactoryServiceImplTest{
     fun snsTopicCreateSuccessful(){
         // mocking
         val snsClient: SnsClient = mockk()
-        val snsCredentialService: SnsCredentialService = mockk()
+        val snsCredentialService: CredentialService = mockk()
         val snsClientSubSystemFacade: SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
         val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
@@ -36,7 +36,7 @@ class SnsTopicFactoryServiceImplTest{
          * 3. snsClient는 HttpStatus isSuccessful를 리턴한다.
          */
         every { snsRequestSubSystemFacade.createTopicRequest(any()) }.returns(any())
-        every { snsCredentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSdkClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.createTopic(any(), snsClient) }.returns(any())
 
         // When:: mockSnsClient는 아무런 sns topic 도 생성하지 못할것을 확신한다.
@@ -46,7 +46,7 @@ class SnsTopicFactoryServiceImplTest{
 
         // Then
         verify(exactly = 1) { snsRequestSubSystemFacade.createTopicRequest(any()) }
-        verify(exactly = 1) { snsCredentialService.getSnsClient() }
+        verify(exactly = 1) { snsCredentialService.getSdkClient() }
         verify(exactly = 1) { snsClientSubSystemFacade.createTopic(any(), snsClient) }
     }
 
@@ -55,14 +55,14 @@ class SnsTopicFactoryServiceImplTest{
     fun snsTopicsWereDisplay(){
         // Given:: mocking
         val snsClient : SnsClient = mockk()
-        val snsCredentialService : SnsCredentialService = mockk()
+        val snsCredentialService: CredentialService = mockk()
         val snsClientSubSystemFacade : SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
         val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
 
         // Given:: stubs
         every { snsRequestSubSystemFacade.createListTopicRequest() }.returns(any())
-        every { snsCredentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSdkClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.getAllTopicsAsList(any(), snsClient) }.returns(any())
 
         // when:: mockSnsClient는 아무런 sns topic 도 가지지 않을 것을 확신한다.
@@ -80,14 +80,14 @@ class SnsTopicFactoryServiceImplTest{
     fun subEmailToTopicArnSuccessful(){
         // Given:: mocking
         val snsClient : SnsClient = mockk()
-        val snsCredentialService : SnsCredentialService = mockk()
+        val snsCredentialService: CredentialService = mockk()
         val snsClientSubSystemFacade : SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
         val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
 
         // Given:: stubs
         every { snsRequestSubSystemFacade.createSubscribeRequest(any(), any()) }.returns(any())
-        every { snsCredentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSdkClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.subscribeEmail(any(), snsClient) }.returns(any())
 
         // When
@@ -105,13 +105,13 @@ class SnsTopicFactoryServiceImplTest{
     fun subArnConfirmCheck(){
         // Given:: mocking
         val snsClient : SnsClient = mockk()
-        val snsCredentialService : SnsCredentialService = mockk()
+        val snsCredentialService: CredentialService = mockk()
         val snsClientSubSystemFacade : SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
         val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
 
         every { snsRequestSubSystemFacade.createConfirmSubscriptionRequest(any(), any()) }.returns(any())
-        every { snsCredentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSdkClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.isAlreadyConfirm(any(), snsClient) }.returns(any())
 
         // when

--- a/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/thirdParty/aws/sns/service/SnsTopicFactoryServiceImplTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.any
 import site.hirecruit.hr.domain.test_util.LocalTest
-import site.hirecruit.hr.thirdParty.aws.service.CredentialService
+import site.hirecruit.hr.thirdParty.aws.service.SnsCredentialService
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsClientSubSystemFacade
 import site.hirecruit.hr.thirdParty.aws.sns.service.facade.SnsRequestSubSystemFacade
 import software.amazon.awssdk.services.sns.SnsClient
@@ -24,10 +24,10 @@ class SnsTopicFactoryServiceImplTest{
     fun snsTopicCreateSuccessful(){
         // mocking
         val snsClient: SnsClient = mockk()
-        val credentialService: CredentialService = mockk()
+        val snsCredentialService: SnsCredentialService = mockk()
         val snsClientSubSystemFacade: SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
-        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(credentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
+        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
 
         /**
          * 1. topicReqest는 mockTopicRequest를 리턴한다.
@@ -36,7 +36,7 @@ class SnsTopicFactoryServiceImplTest{
          * 3. snsClient는 HttpStatus isSuccessful를 리턴한다.
          */
         every { snsRequestSubSystemFacade.createTopicRequest(any()) }.returns(any())
-        every { credentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSnsClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.createTopic(any(), snsClient) }.returns(any())
 
         // When:: mockSnsClient는 아무런 sns topic 도 생성하지 못할것을 확신한다.
@@ -46,7 +46,7 @@ class SnsTopicFactoryServiceImplTest{
 
         // Then
         verify(exactly = 1) { snsRequestSubSystemFacade.createTopicRequest(any()) }
-        verify(exactly = 1) { credentialService.getSnsClient() }
+        verify(exactly = 1) { snsCredentialService.getSnsClient() }
         verify(exactly = 1) { snsClientSubSystemFacade.createTopic(any(), snsClient) }
     }
 
@@ -55,14 +55,14 @@ class SnsTopicFactoryServiceImplTest{
     fun snsTopicsWereDisplay(){
         // Given:: mocking
         val snsClient : SnsClient = mockk()
-        val credentialService : CredentialService = mockk()
+        val snsCredentialService : SnsCredentialService = mockk()
         val snsClientSubSystemFacade : SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
-        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(credentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
+        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
 
         // Given:: stubs
         every { snsRequestSubSystemFacade.createListTopicRequest() }.returns(any())
-        every { credentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSnsClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.getAllTopicsAsList(any(), snsClient) }.returns(any())
 
         // when:: mockSnsClient는 아무런 sns topic 도 가지지 않을 것을 확신한다.
@@ -80,14 +80,14 @@ class SnsTopicFactoryServiceImplTest{
     fun subEmailToTopicArnSuccessful(){
         // Given:: mocking
         val snsClient : SnsClient = mockk()
-        val credentialService : CredentialService = mockk()
+        val snsCredentialService : SnsCredentialService = mockk()
         val snsClientSubSystemFacade : SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
-        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(credentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
+        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
 
         // Given:: stubs
         every { snsRequestSubSystemFacade.createSubscribeRequest(any(), any()) }.returns(any())
-        every { credentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSnsClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.subscribeEmail(any(), snsClient) }.returns(any())
 
         // When
@@ -105,13 +105,13 @@ class SnsTopicFactoryServiceImplTest{
     fun subArnConfirmCheck(){
         // Given:: mocking
         val snsClient : SnsClient = mockk()
-        val credentialService : CredentialService = mockk()
+        val snsCredentialService : SnsCredentialService = mockk()
         val snsClientSubSystemFacade : SnsClientSubSystemFacade = mockk()
         val snsRequestSubSystemFacade: SnsRequestSubSystemFacade = mockk()
-        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(credentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
+        val snsTopicFactoryService = SnsTopicFactoryServiceImpl(snsCredentialService, snsRequestSubSystemFacade, snsClientSubSystemFacade)
 
         every { snsRequestSubSystemFacade.createConfirmSubscriptionRequest(any(), any()) }.returns(any())
-        every { credentialService.getSnsClient() }.returns(snsClient)
+        every { snsCredentialService.getSnsClient() }.returns(snsClient)
         every { snsClientSubSystemFacade.isAlreadyConfirm(any(), snsClient) }.returns(any())
 
         // when


### PR DESCRIPTION
## 작업내용
* CredentialService 인터페이스 계층을 만들었음
  * aws service 마다 다른 IAM 을 사용하기 때문에 계정에 대한 인증을 받는 로직이 개별적으로 존재 함.
  * DIP를 만족 함 추상화에 집중 함.
  * OCP를 만족함 요구사항 변경으로 SdkClient 교체가 일어난다면 구체 클래스(구현부)만 교체하면 됨.
* AwsSnsConfig 를 추가 함