### PR TITLE
Fix develop branch build fail

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
@@ -27,4 +27,27 @@ open class AuthUserInfo @QueryProjection constructor(
     override fun toString(): String {
         return "AuthUserInfo(githubId=$githubId, name='$name', email=$email, profileUri='$profileImgUri', role=$role)"
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AuthUserInfo) return false
+
+        if (githubId != other.githubId) return false
+        if (name != other.name) return false
+        if (email != other.email) return false
+        if (profileImgUri != other.profileImgUri) return false
+        if (role != other.role) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = githubId.hashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + (email?.hashCode() ?: 0)
+        result = 31 * result + profileImgUri.hashCode()
+        result = 31 * result + role.hashCode()
+        return result
+    }
+
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthentication.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthentication.kt
@@ -42,15 +42,16 @@ class UserRegistrationServiceWithoutEmailAuthentication(
             Role.UNAUTHENTICATED_EMAIL
         )
         val savedUserEntity = userRepository.save(userEntity)
-
-        // UserRegistrationEvent발생시킴. 타 도메인 로직(ex. workerEntity 생성 등...)은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
-        publisher.publishEvent(UserRegistrationEvent(savedUserEntity.githubId, userRegistrationInfo.workerDto))
-        return AuthUserInfo(
+        val registrationAuthUserInfo = AuthUserInfo(
             githubId = savedUserEntity.githubId,
             name = savedUserEntity.name,
             email = savedUserEntity.email,
             profileImgUri = savedUserEntity.profileImgUri,
             role = savedUserEntity.role
         )
+
+        // UserRegistrationEvent발생시킴. 타 도메인 로직(ex. workerEntity 생성 등...)은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
+        publisher.publishEvent(UserRegistrationEvent(registrationAuthUserInfo, userRegistrationInfo.workerDto))
+        return registrationAuthUserInfo
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspect.kt
@@ -17,7 +17,7 @@ import site.hirecruit.hr.domain.worker.dto.WorkerDto
 @Aspect
 class WorkerUpdateColumnsVerifierAspect {
 
-    @Pointcut("execution(* site.hirecruit.hr.domain.worker.service.AuthUserWorkerService+.update(..))")
+    @Pointcut("execution(* site.hirecruit.hr.domain.worker.service.AuthUserWorkerService+.updateWorkerEntityByAuthUserInfo(..))")
     private fun authUserWorkerService_updateMethodPointCut(){}
 
     @Before("authUserWorkerService_updateMethodPointCut()")

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerService.kt
@@ -20,6 +20,8 @@ interface AuthUserWorkerService {
 
     /**
      * [AuthUserInfo]정보를 기반으로 조회한 WorkerEntity를 변경한다.
+     *
+     * @see site.hirecruit.hr.domain.worker.aop.WorkerUpdateColumnsVerifierAspect
      */
     fun updateWorkerEntityByAuthUserInfo(authUserInfo: AuthUserInfo, updateDto: WorkerDto.Update)
 

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
@@ -62,7 +62,7 @@ internal class UserRegistrationServiceImplTest{
         //then
         verify(exactly = 1) {userRepository.save(userEntity)}
         verify(exactly = 1) {emailAuthenticationService.send(tempUserAuthUserInfo, userRegistrationDto.email)}
-        val userRegistrationEvent = UserRegistrationEvent(tempUserAuthUserInfo.githubId, userRegistrationDto.workerDto)
+        val userRegistrationEvent = UserRegistrationEvent(tempUserAuthUserInfo, userRegistrationDto.workerDto)
         verify(exactly = 1) {publisher.publishEvent(userRegistrationEvent)}
 
         // 임시 유저일 떄의 Role과 registration()를 수행한 유저일 때의 Role은 다르다.

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthenticationTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthenticationTest.kt
@@ -22,7 +22,7 @@ import kotlin.random.Random
 internal class UserRegistrationServiceWithoutEmailAuthenticationTest{
 
 
-    private val publisher: ApplicationEventPublisher = spyk()
+    private val publisher: ApplicationEventPublisher = mockk(relaxed = true)
     private val emailAuthenticationService: EmailAuthenticationService = spyk()
 
     @Test
@@ -55,6 +55,13 @@ internal class UserRegistrationServiceWithoutEmailAuthenticationTest{
             profileImgUri = tempUserAuthUserInfo.profileImgUri,
             role = Role.UNAUTHENTICATED_EMAIL
         )
+        val registrationAuthUserInfo = AuthUserInfo(
+            githubId = userEntity.githubId,
+            name = userEntity.name,
+            email = userEntity.email,
+            profileImgUri = userEntity.profileImgUri,
+            userEntity.role
+        )
 
         /**
          * User를 저장하는 UserRepository 이외에는 메서드에 대한 리턴값이 비즈니스 로직에 영향을 미치지 않는다.
@@ -66,7 +73,7 @@ internal class UserRegistrationServiceWithoutEmailAuthenticationTest{
 
         //then
         verify(exactly = 1) {userRepository.save(userEntity)}
-        val userRegistrationEvent = UserRegistrationEvent(tempUserAuthUserInfo.githubId, userRegistrationDto.workerDto)
+        val userRegistrationEvent = UserRegistrationEvent(registrationAuthUserInfo, userRegistrationDto.workerDto)
         verify(exactly = 1) {publisher.publishEvent(userRegistrationEvent)}
         verify(exactly = 0) {emailAuthenticationService.send(any(), any())} // email 인증을 수행하지 않는다.
 

--- a/src/test/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspectTest.kt
@@ -83,12 +83,6 @@ internal class WorkerUpdateColumnsVerifierAspectTest{
             factory.addAspect(WorkerUpdateColumnsVerifierAspect())
             val proxy = factory.getProxy<AuthUserWorkerService>()
 
-            val nullValue = WorkerDto.Update(
-                introduction = null,
-                updateColumns = listOf(
-                    WorkerDto.Update.Column.INTRODUCTION,
-                )
-            )
             val blankValue = WorkerDto.Update(
                 introduction = "     ",
                 updateColumns = listOf(
@@ -140,12 +134,6 @@ internal class WorkerUpdateColumnsVerifierAspectTest{
             factory.addAspect(WorkerUpdateColumnsVerifierAspect())
             val proxy = factory.getProxy<AuthUserWorkerService>()
 
-            val nullValue = WorkerDto.Update(
-                giveLink = null,
-                updateColumns = listOf(
-                    WorkerDto.Update.Column.GIVE_LINK,
-                )
-            )
             val blankValue = WorkerDto.Update(
                 giveLink = "     ",
                 updateColumns = listOf(
@@ -167,12 +155,6 @@ internal class WorkerUpdateColumnsVerifierAspectTest{
             factory.addAspect(WorkerUpdateColumnsVerifierAspect())
             val proxy = factory.getProxy<AuthUserWorkerService>()
 
-            val nullValue = WorkerDto.Update(
-                devYear = null,
-                updateColumns = listOf(
-                    WorkerDto.Update.Column.DEV_YEAR,
-                )
-            )
             val blankValue = WorkerDto.Update(
                 devYear = -1,
                 updateColumns = listOf(


### PR DESCRIPTION
### 원인
- `AuthUserWorkerService.update()` 를 `updateWorkerEntityByAuthUserInfo()`로 바꾼 후 해당 메서드에 적용된 AOP pointcut을 수정하지 않음 연관된 pr:  #58 
   > 해당 부분은 주석으로 문서화
- 리펙토링중 누락한 mismatch parameter
