### PR TITLE
Worker domain refactoring

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspect.kt
@@ -33,7 +33,7 @@ class WorkerUpdateColumnsVerifierAspect {
     fun verifyUpdateDtoProperty(updateDto: WorkerDto.Update){
         updateDto.updateColumns.forEach {
             when(it) {
-                WorkerDto.Update.Column.COMPANY         -> verifyCompanyColumn(updateDto.company)
+                WorkerDto.Update.Column.COMPANY_NAME         -> verifyCompanyNameColumn(updateDto.companyName)
                 WorkerDto.Update.Column.LOCATION        -> verifyLocationColumn(updateDto.location)
                 WorkerDto.Update.Column.INTRODUCTION    -> verifyIntroduction(updateDto.introduction)
                 WorkerDto.Update.Column.GIVE_LINK       -> verifyGiveLink(updateDto.giveLink)
@@ -42,9 +42,9 @@ class WorkerUpdateColumnsVerifierAspect {
         }
     }
 
-    private fun verifyCompanyColumn(company: String?){
-        if(company == null || company.isBlank())
-            throw IllegalArgumentException("company must not be blank. company='$company'")
+    private fun verifyCompanyNameColumn(companyName: String?){
+        if(companyName == null || companyName.isBlank())
+            throw IllegalArgumentException("companyName must not be blank. companyName='$companyName'")
     }
 
     private fun verifyLocationColumn(location: String?) {

--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -13,7 +13,7 @@ class WorkerDto {
 
     data class Registration(
         @field:NotBlank
-        val company: String,
+        val companyName: String,
 
         @field:NotBlank
         val location: String,
@@ -30,7 +30,7 @@ class WorkerDto {
 
         val profileImgUri: String,
 
-        val company: String,
+        val companyName: String,
 
         val location: String,
 
@@ -42,7 +42,7 @@ class WorkerDto {
     )
 
     data class Update(
-        val company: String? = null,
+        val companyName: String? = null,
 
         val location: String? = null,
 
@@ -57,7 +57,7 @@ class WorkerDto {
     ){
 
         enum class Column{
-            COMPANY, LOCATION, INTRODUCTION, GIVE_LINK, DEV_YEAR
+            COMPANY_NAME, LOCATION, INTRODUCTION, GIVE_LINK, DEV_YEAR
         }
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -7,8 +7,8 @@ import javax.persistence.*
 
 @Entity @Table(name = "worker")
 class WorkerEntity(
-    @Column(name = "company", nullable = false)
-    var company: String,
+    @Column(name = "companyName", nullable = false)
+    var companyName: String,
 
     @Column(name = "location", nullable = false)
     var location: String,

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -21,6 +21,9 @@ class WorkerEntity(
 
     devYear: Int? = null,
 
+    @Column(name = "position", nullable = false)
+    var position: String? = null, //확장을 위해 enum 사용하지 않음 직군이 너무 많음
+
     @OneToOne(fetch = FetchType.LAZY) @JoinColumn(name = "user_id")
     @OnDelete(action = OnDeleteAction.CASCADE)
     val user: UserEntity

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
@@ -7,9 +7,10 @@ import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository
 
 /**
- * AuthUser
+ * AuthUserWorkerService 인증된 유저의 Worker service
  *
  * @author 정시원
+ * @since 1.0
  */
 @Service
 class AuthUserWorkerServiceImpl(

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
@@ -24,7 +24,7 @@ class AuthUserWorkerServiceImpl(
             name = authUserInfo.name,
             email = authUserInfo.email!!,
             profileImgUri = authUserInfo.profileImgUri,
-            company = workerEntity.company,
+            companyName = workerEntity.companyName,
             location = workerEntity.location,
             introduction = workerEntity.introduction,
             giveLink = workerEntity.giveLink,
@@ -38,7 +38,7 @@ class AuthUserWorkerServiceImpl(
             ?: throw IllegalArgumentException("Invalid authentication information. So 'WorkerEntity' could not be found. authUserInfo = '${authUserInfo}' ")
         updateDto.updateColumns.forEach {
             when(it) {
-                WorkerDto.Update.Column.COMPANY         -> workerEntity.company = updateDto.company!!
+                WorkerDto.Update.Column.COMPANY_NAME         -> workerEntity.companyName = updateDto.companyName!!
                 WorkerDto.Update.Column.LOCATION        -> workerEntity.location = updateDto.location!!
                 WorkerDto.Update.Column.INTRODUCTION    -> workerEntity.introduction = updateDto.introduction
                 WorkerDto.Update.Column.GIVE_LINK       -> workerEntity.giveLink = updateDto.giveLink

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationService.kt
@@ -16,6 +16,7 @@ interface WorkerRegistrationService {
     /**
      * [AuthUserInfo]와 [WorkerDto.Registration]를 기반으로 [WorkerEntity]를 생성 및 저장한다.
      *
+     * @see site.hirecruit.hr.global.event.UserRegistrationEventHandler.createWorker
      * @return Worker의 정보
      */
     fun registration(authUserInfo: AuthUserInfo, registrationDto: WorkerDto.Registration): WorkerDto.Info

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
@@ -24,7 +24,7 @@ class WorkerRegistrationServiceImpl(
             ?: throw IllegalStateException("Cannot found UserEntity, githubId='${authUserInfo.githubId}'")
         val savedWorkerEntity = workerRepository.save(
             WorkerEntity(
-                company = registrationDto.company,
+                companyName = registrationDto.companyName,
                 location = registrationDto.location,
                 introduction = registrationDto.introduction,
                 giveLink = registrationDto.giveLink,
@@ -36,7 +36,7 @@ class WorkerRegistrationServiceImpl(
             name = authUserInfo.name,
             email = authUserInfo.email!!,
             profileImgUri = authUserInfo.profileImgUri,
-            company = savedWorkerEntity.company,
+            companyName = savedWorkerEntity.companyName,
             location = savedWorkerEntity.location,
             introduction = savedWorkerEntity.introduction,
             giveLink = savedWorkerEntity.giveLink,

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
@@ -60,7 +60,7 @@ internal class UserRegistrationAspectTest{
             email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
             name = RandomString.make(5),
             workerDto = WorkerDto.Registration(
-                company = RandomString.make(8),
+                companyName = RandomString.make(8),
                 location = RandomString.make(8)
             )
         )

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
@@ -32,7 +32,7 @@ internal class UserRegistrationServiceImplTest{
             email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
             name = RandomString.make(5),
             workerDto = WorkerDto.Registration(
-                company = RandomString.make(5),
+                companyName = RandomString.make(5),
                 location = RandomString.make(5),
             )
         )
@@ -96,7 +96,7 @@ internal class UserRegistrationServiceImplTest{
             email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
             name = null,    // UserRegistrationDto.email = null
             workerDto = WorkerDto.Registration(
-                company = RandomString.make(5),
+                companyName = RandomString.make(5),
                 location = RandomString.make(5),
             )
         )

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthenticationTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthenticationTest.kt
@@ -37,7 +37,7 @@ internal class UserRegistrationServiceWithoutEmailAuthenticationTest{
             email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
             name = RandomString.make(5),
             workerDto = WorkerDto.Registration(
-                company = RandomString.make(5),
+                companyName = RandomString.make(5),
                 location = RandomString.make(5),
             )
         )
@@ -109,7 +109,7 @@ internal class UserRegistrationServiceWithoutEmailAuthenticationTest{
             email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
             name = null,    // UserRegistrationDto.email = null
             workerDto = WorkerDto.Registration(
-                company = RandomString.make(5),
+                companyName = RandomString.make(5),
                 location = RandomString.make(5),
             )
         )

--- a/src/test/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/aop/WorkerUpdateColumnsVerifierAspectTest.kt
@@ -25,13 +25,13 @@ internal class WorkerUpdateColumnsVerifierAspectTest{
         val proxy = factory.getProxy<AuthUserWorkerService>()
 
         val updateDto = WorkerDto.Update(
-            company = RandomString.make(10),
+            companyName = RandomString.make(10),
             location = RandomString.make(10),
             introduction = RandomString.make(10),
             giveLink = RandomString.make(10),
             devYear = Random.nextInt(0, 30),
             updateColumns = listOf( // 변경할 컬럼
-                WorkerDto.Update.Column.COMPANY,
+                WorkerDto.Update.Column.COMPANY_NAME,
                 WorkerDto.Update.Column.LOCATION,
                 WorkerDto.Update.Column.INTRODUCTION,
                 WorkerDto.Update.Column.GIVE_LINK,
@@ -48,21 +48,21 @@ internal class WorkerUpdateColumnsVerifierAspectTest{
     inner class ValidationFailTest{
 
         @Test
-        internal fun company() {
+        internal fun companyName() {
             val factory = AspectJProxyFactory(proxy)
             factory.addAspect(WorkerUpdateColumnsVerifierAspect())
             val proxy = factory.getProxy<AuthUserWorkerService>()
 
             val nullValue = WorkerDto.Update(
-                company = null,
+                companyName = null,
                 updateColumns = listOf(
-                    WorkerDto.Update.Column.COMPANY,
+                    WorkerDto.Update.Column.COMPANY_NAME,
                 )
             )
             val blankValue = WorkerDto.Update(
-                company = "     ",
+                companyName = "     ",
                 updateColumns = listOf(
-                    WorkerDto.Update.Column.COMPANY,
+                    WorkerDto.Update.Column.COMPANY_NAME,
                 )
             )
 
@@ -158,7 +158,7 @@ internal class WorkerUpdateColumnsVerifierAspectTest{
             val blankValue = WorkerDto.Update(
                 devYear = -1,
                 updateColumns = listOf(
-                    WorkerDto.Update.Column.COMPANY,
+                    WorkerDto.Update.Column.COMPANY_NAME,
                 )
             )
 

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImplTest.kt
@@ -63,7 +63,7 @@ class AuthUserWorkerServiceImplTest(
         })
 
         assertAll({
-            assertEquals(workerEntity.company, myWorkerInfo.company)
+            assertEquals(workerEntity.companyName, myWorkerInfo.companyName)
             assertEquals(workerEntity.location, myWorkerInfo.location)
             assertEquals(workerEntity.introduction, workerEntity.introduction)
             assertEquals(workerEntity.devYear, workerEntity.devYear)
@@ -76,13 +76,13 @@ class AuthUserWorkerServiceImplTest(
         // given
         val workerEntity = workerEntityDeepCopy(createWorkerEntity())
         val updateDto = WorkerDto.Update(
-            company = RandomString.make(10),
+            companyName = RandomString.make(10),
             location = RandomString.make(10),
             introduction = RandomString.make(10),
             giveLink = RandomString.make(10),
             devYear = Random.nextInt(0, 30),
             updateColumns = listOf( // 변경할 컬럼
-                WorkerDto.Update.Column.COMPANY,
+                WorkerDto.Update.Column.COMPANY_NAME,
                 WorkerDto.Update.Column.LOCATION,
                 WorkerDto.Update.Column.INTRODUCTION,
                 WorkerDto.Update.Column.GIVE_LINK,
@@ -97,7 +97,7 @@ class AuthUserWorkerServiceImplTest(
         //then
         val updatedWorkerEntity = workerRepository.findByUser_GithubId(authUserInfo.githubId)
         assertAll("업데이터 전에 조회한 WorkerEntity의 값과 Update후 조회된 WorkerEntity의 값은 달라야 한다.", {
-            assertNotEquals(workerEntity.company, updatedWorkerEntity?.company)
+            assertNotEquals(workerEntity.companyName, updatedWorkerEntity?.companyName)
             assertNotEquals(workerEntity.location, updatedWorkerEntity?.location)
             assertNotEquals(workerEntity.introduction, updatedWorkerEntity?.introduction)
             assertNotEquals(workerEntity.giveLink, updatedWorkerEntity?.giveLink)
@@ -105,7 +105,7 @@ class AuthUserWorkerServiceImplTest(
         })
 
         assertAll("UpdateDto에 저장된, 값들은 update후 조회된 Entity에 반영되어야 한다.", {
-            assertEquals(updateDto.company, updatedWorkerEntity?.company)
+            assertEquals(updateDto.companyName, updatedWorkerEntity?.companyName)
             assertEquals(updateDto.location, updatedWorkerEntity?.location)
             assertEquals(updateDto.introduction, updatedWorkerEntity?.introduction)
             assertEquals(updateDto.giveLink, updatedWorkerEntity?.giveLink)
@@ -115,7 +115,7 @@ class AuthUserWorkerServiceImplTest(
 
     private fun createWorkerEntity() = workerRepository.save(
         WorkerEntity(
-            company = RandomString.make(5),
+            companyName = RandomString.make(5),
             location = RandomString.make(15),
             introduction = RandomString.make(15),
             giveLink = RandomString.make(15),
@@ -133,7 +133,7 @@ class AuthUserWorkerServiceImplTest(
     )
 
     private fun workerEntityDeepCopy(workerEntity: WorkerEntity): WorkerEntity = WorkerEntity(
-        company = workerEntity.company,
+        companyName = workerEntity.companyName,
         location = workerEntity.location,
         introduction = workerEntity.introduction,
         giveLink = workerEntity.giveLink,

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
@@ -36,7 +36,7 @@ internal class WorkerRegistrationServiceImplTest{
             role = authUserInfo.role
         )
         val workerEntity = WorkerEntity(
-            company = registrationDto.company,
+            companyName = registrationDto.companyName,
             location = registrationDto.location,
             giveLink = registrationDto.giveLink,
             introduction = registrationDto.introduction,
@@ -59,7 +59,7 @@ internal class WorkerRegistrationServiceImplTest{
             assertEquals(authUserInfo.name, registrationWorkerInfo.name)
             assertEquals(authUserInfo.email, registrationWorkerInfo.email)
             assertEquals(authUserInfo.profileImgUri, registrationWorkerInfo.profileImgUri)
-            assertEquals(registrationDto.company, registrationWorkerInfo.company)
+            assertEquals(registrationDto.companyName, registrationWorkerInfo.companyName)
             assertEquals(registrationDto.location, registrationWorkerInfo.location)
             assertEquals(registrationDto.introduction, registrationWorkerInfo.introduction)
             assertEquals(registrationDto.giveLink, registrationWorkerInfo.giveLink)
@@ -81,7 +81,7 @@ internal class WorkerRegistrationServiceImplTest{
     }
 
     private fun makeRegistrationDto() = WorkerDto.Registration(
-        company = RandomString.make(7),
+        companyName = RandomString.make(7),
         location = RandomString.make(15),
         giveLink = RandomString.make(15),
         introduction = RandomString.make(15),


### PR DESCRIPTION
## 개요
- Worker도메인에 주석 보충
- worker의 서브도메인인 company 도메인을 만들기 위해 `company` 프로퍼티 및 문자열 모두 `company_name`으로 변경.
- workerEntity에 직군을 담기위해 position 프로퍼티 추가


## ERD
<img width="684" alt="CleanShot 2022-05-27 at 12 20 37@2x" src="https://user-images.githubusercontent.com/62932968/170622569-3684c0cd-0561-413c-ab02-f546976c197a.png">

## 앞으로 할 일
- company 도메인 설게 및 개발
- worker 도메인과 company 도메인 결합 및 개발
- 통합 테스트
