### PR TITLE
FIx gradle build 후 jar 파일이 실행안되는 현상 해결

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,9 @@ noArg {
     annotation("site.hirecruit.hr.global.annotation.Dto")
 }
 
-group = "com.kts"
-version = "0.0.1-SNAPSHOT"
+group = "site.hirecruit.hr"
+base.archivesBaseName = "hirecruit"
+version = "0.1"
 java.sourceCompatibility = JavaVersion.VERSION_11
 val qeurydslVersion = "5.0.0"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,24 +87,6 @@ dependencies {
     testImplementation("it.ozimov:embedded-redis:0.7.2")
 }
 
-/**
- * jar setting with kotlin spring
- */
-tasks.withType<Jar> {
-    manifest {
-        attributes["Main-Class"] = "site.hirecruit.hr.HRApplicationKt"
-        archiveFileName.set("hirecruit-1.0.jar") // .jar name: name.jar
-    }
-
-    // To add all of the dependencies
-    from(sourceSets.main.get().output)
-
-    dependsOn(configurations.runtimeClasspath)
-    from({
-        configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
-    })
-}
-
 /** Querydsl 이 만들어주는 Qclass 경로 지정 **/
 sourceSets["main"].withConvention(org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet::class) {
     kotlin.srcDir("$buildDir/generated/source/kapt/main")


### PR DESCRIPTION
## 버그 원인
기존 build.gradle.kts에 93 ~ 106줄에 있는 Jar테스크를 커스텀 한 부분으로 인해 해당 오류가 발생함
[build.gradle.kts](https://github.com/themoment-team/HiRecruit-server/compare/develop...hotfix/jar?expand=1#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06L90-L106)

## 해결방법
jar 파일 이름 생성 패턴은 `{base.archivesBaseName}-{version}.jar` 이와 같으므로 값을 설정해줌 29 ~ 31줄 참고
<img width="286" alt="CleanShot 2022-06-01 at 17 45 06@2x" src="https://user-images.githubusercontent.com/62932968/171364936-4822fbe9-9e01-4940-811b-15163b43110e.png">
