### PR TITLE
Feature Bean Validator Exception handling

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/exception/GlobalExceptionHandler.kt
@@ -2,6 +2,8 @@ package site.hirecruit.hr.global.exception
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindingResult
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.client.HttpClientErrorException
@@ -26,4 +28,40 @@ class GlobalExceptionHandler {
     private fun illegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ExceptionResponseEntity> =
         ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
             .body(ExceptionResponseEntity.of(ex))
+
+    /**
+     * Spring Bean Validation Handler
+     *
+     * 반환 메세지 예시
+     * ```json
+     * {
+     *    "message": "'name':'공백일 수 없습니다.', 'homepageUri':'올바른 URL이어야 합니다.', 'location':'공백일 수 없습니다.', 'companyImgUri':'공백일 수 없습니다.'"
+     * }
+     * ```
+     */
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    private fun validationException(ex: MethodArgumentNotValidException): ResponseEntity<ExceptionResponseEntity>{
+        val bindingResult: BindingResult = ex.bindingResult
+
+        val errorResult = StringBuilder()
+        for (fieldError in bindingResult.fieldErrors) {
+            /**
+             * 유효성검사에 통과하지 못한 field name, field name의 접두사에 "_"가 있다면 제거한다.
+             */
+            val fieldErrorName = fieldError.field.removePrefix("_")
+
+            /**
+             * 유효성 검사에 통과하지 못한 field에 대한 메시지
+             */
+            val errorMessage = fieldError.defaultMessage
+
+            errorResult.append("'$fieldErrorName'").append(":")
+            errorResult.append("'${errorMessage}.'")
+            errorResult.append(", ")
+        }
+        errorResult.delete(errorResult.lastIndexOf(", "), errorResult.lastIndex + 1) // 마지막 리스트일 경우  ", " 문자열을 제거한다.
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
+            .body(ExceptionResponseEntity(errorResult.toString()))
+    }
 }

--- a/src/main/java/site/hirecruit/hr/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package site.hirecruit.hr.global.exception
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -19,5 +20,10 @@ class GlobalExceptionHandler {
     @ExceptionHandler(HttpStatusCodeException::class)
     private fun httpStatusException(ex: HttpClientErrorException): ResponseEntity<ExceptionResponseEntity> =
         ResponseEntity.status(ex.statusCode.value())
+            .body(ExceptionResponseEntity.of(ex))
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    private fun illegalArgumentException(ex: IllegalArgumentException): ResponseEntity<ExceptionResponseEntity> =
+        ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
             .body(ExceptionResponseEntity.of(ex))
 }

--- a/src/main/java/site/hirecruit/hr/global/exception/model/ExceptionResponseEntity.kt
+++ b/src/main/java/site/hirecruit/hr/global/exception/model/ExceptionResponseEntity.kt
@@ -3,8 +3,7 @@ package site.hirecruit.hr.global.exception.model
 /**
  * Exception발생시 클라이언트에 반환할 Response 객체입니다.
  *
- * ### notice
- * 해당 클래스는 정적 팩토리 매서드로 생성할 수 있습니다. 다음은 Spring RestControllerAdvice로 예외를 핸들링하는 예제입니다..
+ * 해당 클래스는 정적 팩토리 매서드로도 생성할 수 있습니다. 다음은 Spring RestControllerAdvice로 예외를 핸들링하는 예제입니다..
  * ```kotlin
  *  @ExceptionHandler(HttpStatusCodeException::class)
  *  private fun httpStatusException(ex: HttpClientErrorException): ResponseEntity<ExceptionResponseEntity> =
@@ -15,7 +14,7 @@ package site.hirecruit.hr.global.exception.model
  * @author 정시원
  * @since 1.0
  */
-class ExceptionResponseEntity private constructor(
+class ExceptionResponseEntity (
     val message: String?
 ) {
     companion object{


### PR DESCRIPTION
## 개요
Bean Validator를 통해 검증이 실패하면 client에 custom한 message를 전달하는 로직을 작성했습니다.

#### 예시
```json
{
  "message": "'homepageUri':'올바른 URL이어야 합니다.', 'companyImgUri':'공백일 수 없습니다.', 'location':'공백일 수 없습니다.', 'name':'공백일 수 없습니다.'"
}
```