### PR TITLE
#96 후속 PR Spring Bean Validator 로직 보안

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/exception/GlobalExceptionHandler.kt
@@ -47,8 +47,11 @@ class GlobalExceptionHandler {
         for (fieldError in bindingResult.fieldErrors) {
             /**
              * 유효성검사에 통과하지 못한 field name, field name의 접두사에 "_"가 있다면 제거한다.
+             * "Dto._"문자를 "."로 치환한다.
              */
-            val fieldErrorName = fieldError.field.removePrefix("_")
+            val fieldErrorName = fieldError.field
+                .removePrefix("_")
+                .replace("Dto._", ".")
 
             /**
              * 유효성 검사에 통과하지 못한 field에 대한 메시지


### PR DESCRIPTION
## 개요
해당 PR은 #96 후속 PR입니다.

객체 속에있는 객체를 `@Valid`를 통해 검증할 때 검증이 실패하게 된다면 클라이언트에 다음과 같은 형식으로 반환합니다,
```json
{
  "message": "'workerDto._companyId':'널이어서는 안됩니다.'"
}
```
Dto._ 를 제거하여 다음과 같이 반환하도록 알고리즘을 개선했습니다.
```json
{
  "message": "'workerDto._companyId':'널이어서는 안됩니다.'"
}
```