### PR TITLE
Add 운영환경에서 테스트 전용 profile(prod-test) 추가

### DIFF
--- a/src/main/resources/application-prod-test.yml
+++ b/src/main/resources/application-prod-test.yml
@@ -1,0 +1,59 @@
+server:
+  port: 8080
+
+  # UTF-8 사용
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
+
+spring:
+  config:
+    import: classpath:oauth/github-oauth.yml
+
+  session:
+    store-type: redis
+    redis:
+      flush-mode: on_save
+      namespace: spring:session # redis에 세션 저장시 네임스페이스
+
+  redis:
+    host: ${redis.host}
+    password:
+    port: 6379
+
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
+  #H2 DataBase
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+      settings:
+        web-allow-others: true
+
+  #DB 설정
+  datasource:
+    url: jdbc:h2:mem:HR
+    driver-class-name: org.h2.Driver
+    username: sa
+
+  ### JPA 설정 ###
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        hbm2ddl:
+          auto: create
+    show-sql: true
+
+### Logging ###
+logging:
+  level:
+    org.hibernate.type.descriptor.sql : trace
+    site.hirecruit.hr : debug


### PR DESCRIPTION
## 개요
운영환경에서 테스트할 수 있도록 prod-test프로필을 추가했습니다. 
기존 local의 차이점은 외부 환경변수 `redis.host`를 통해 redis의 호스트를 설정할 수 있습니다.