### PR TITLE
Fix cookie domain typo

### DIFF
--- a/src/main/resources/application-prod-test.yml
+++ b/src/main/resources/application-prod-test.yml
@@ -10,7 +10,7 @@ server:
 
     session:
       cookie:
-        domain: hirecruit.com
+        domain: hirecruit.site
         max-age: 36000
         secure: true
         same-site: none


### PR DESCRIPTION
## 개요 
쿠키 도메인을 잘못적었습니다 hirecruit.com -> hirecruit.site #128 