### PR TITLE
OAuth2 login 후 보내주는 is-first query parame sanke_case로 변경

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/handler/OAuthLoginSuccessHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/OAuthLoginSuccessHandler.kt
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletResponse
 @Component
 class OAuthLoginSuccessHandler(
     @Value("\${oauth2.login.success.redirect-base-uri}") val redirectBaseUri: String,
-    @Value("\${hr.domain}") val cookieDomain: String
 ): AuthenticationSuccessHandler {
     /**
      * oauth2 login성공 후 쿠키를 SameSite None으로 설정 후 프론트엔드 웹사이트로 리다이렉트
@@ -43,8 +42,8 @@ class OAuthLoginSuccessHandler(
 
         val isGuest = (authentication.authorities as Collection<GrantedAuthority>)
             .contains(SimpleGrantedAuthority(Role.GUEST.role))
-        if(isGuest)
-            redirectUri += "?is-first=true"
+        if(isGuest) redirectUri += "?is_first=true"
+
         return redirectUri
     }
 }


### PR DESCRIPTION
## 개요
JavaScript에서 쿼리 스트링의 객채 체이닝이 불가능하여 `is-first`를 `is_first`로 변경합니다.

[GET] /api/v1/auth/oauth2/authorization/github - GitHub OAuth 로그인 API명세를 확인해주세요

요청자: @sunwoo0706