### PR TITLE
Hotfix user registration API  companyId가 null이 아니여도 400 BadRequest 반환

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -1,9 +1,12 @@
 package site.hirecruit.hr.domain.worker.dto
 
+import com.fasterxml.jackson.annotation.JsonGetter
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.querydsl.core.annotations.QueryProjection
 import org.hibernate.validator.constraints.URL
 import site.hirecruit.hr.domain.company.dto.CompanyDto
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
 
@@ -16,7 +19,8 @@ import javax.validation.constraints.NotNull
 class WorkerDto {
 
     data class Registration(
-        @field:NotNull
+        @field:JsonProperty("companyId") @get:JsonGetter("companyId")
+        @field:NotNull @field:Min(1)
         val _companyId: Long?, // validation 을 사용하기 위해 추가
         val giveLink: String? = null,
         val introduction: String? = null,


### PR DESCRIPTION
## 개요
다음과 같이 user registration API에서 companyId가 null이 아니어도
```json
{
    "email": "siwon103305@gmail.com",
    "name": "string",
    "worker": {
        "companyId": 1, // 여기
        "devYear": 0, 
        "giveLink": "string",
        "introduction": "string",
        "position": "string"
    }
}
```
다음과 같이 companyId가 null이라고 message에서 알려주고 Bad Request가 발생하는 오류가 있었습니다.
```json
400 Bad Rquest
{
    "message": "'worker.companyId':'널이어서는 안됩니다.'"
}
```
## 해결방안
`_companyId`프로퍼티에 `@field:JsonProperty("companyId")` `@get:JsonGetter("companyId")`를 사용하여  JsonProperty와 JsonGetter값을 맞춰주었습니다. 결국 getter 매핑 문제였습니다.

@sunwoo0706 해당 pr merge후 fix될 예정입니다..