### PR TITLE
CompanyId가 company를 조회할 수 있는지 검증하는 validator 추가

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/company/validator/CompanyExistValidator.kt
+++ b/src/main/java/site/hirecruit/hr/domain/company/validator/CompanyExistValidator.kt
@@ -1,0 +1,30 @@
+package site.hirecruit.hr.domain.company.validator
+
+import org.springframework.stereotype.Component
+import site.hirecruit.hr.domain.company.validator.annoation.CompanyIsNotExistByCompanyId
+import site.hirecruit.hr.domain.company.repository.CompanyRepository
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+/**
+ * companyId로 company가 존재하는지 검증하는 Validator
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+@Component
+class CompanyExistValidator(
+    private val companyRepository: CompanyRepository
+): ConstraintValidator<CompanyIsNotExistByCompanyId, Long> {
+
+    /**
+     * @param value Long으로 변환가능한 문자열
+     */
+    override fun isValid(value: Long?, context: ConstraintValidatorContext?): Boolean {
+        if(value == null)
+            return true
+
+        val companyId: Long = value.toLong()
+        return companyRepository.existsById(companyId)
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/company/validator/annoation/CompanyIsNotExistByCompanyId.kt
+++ b/src/main/java/site/hirecruit/hr/domain/company/validator/annoation/CompanyIsNotExistByCompanyId.kt
@@ -1,0 +1,22 @@
+package site.hirecruit.hr.domain.company.validator.annoation
+
+import site.hirecruit.hr.domain.company.validator.CompanyExistValidator
+import javax.validation.Constraint
+import javax.validation.Payload
+import kotlin.reflect.KClass
+
+/**
+ * CompanyId에 해당하는 company가 존재하는지 검증하는 validator
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+@MustBeDocumented
+@Constraint(validatedBy = [CompanyExistValidator::class])
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CompanyIsNotExistByCompanyId(
+    val message: String = "해당 Company를 찾을 수 없습니다",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+)

--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.querydsl.core.annotations.QueryProjection
 import org.hibernate.validator.constraints.URL
 import site.hirecruit.hr.domain.company.dto.CompanyDto
+import site.hirecruit.hr.domain.company.validator.annoation.CompanyIsNotExistByCompanyId
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotEmpty
@@ -20,7 +21,7 @@ class WorkerDto {
 
     data class Registration(
         @field:JsonProperty("companyId") @get:JsonGetter("companyId")
-        @field:NotNull @field:Min(1)
+        @field:NotNull @field:Min(1) @field:CompanyIsNotExistByCompanyId
         val _companyId: Long?, // validation 을 사용하기 위해 추가
         val giveLink: String? = null,
         val introduction: String? = null,


### PR DESCRIPTION
## 개요
Bean Validator를 사용하여 `companyId`가 `company`를 조회할 수 있는지 검증하는 validator 추가했습니다.

예시로 `[POST] /api/v1/auth/registration - 회원가입 첫 Github OAuth로그인 후` API에서 존재하지 않은 companyId를 전달하면 다음과 같은 error responseBady를 반환합니다.
```json
400 Bad Request
{
    "message": "'worker.companyId':'해당 'companyId'로 회사(company)를 찾을 수 없습니다.'"
}
```

### 로직을 작성한 이유
Worker를 등록 할 때 worker는 무조건 company에 소속되어야 하므로 해당 validator 를 생성했습니다.