### PR TITLE
endpoint 권한설정

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -1,7 +1,9 @@
 package site.hirecruit.hr.global.security
 
+import org.apache.tomcat.util.descriptor.web.SecurityRoleRef
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.context.support.BeanDefinitionDsl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
@@ -56,6 +58,9 @@ class SecurityConfig(
                         "/api/v1/worker/me",
                         "/api/v1/worker/me/**"
                     ).hasAnyRole(Role.UNAUTHENTICATED_EMAIL.role, Role.CLIENT.role)
+                    it.antMatchers(
+                        "/api/v1/auth/registration"
+                    ).hasRole(Role.GUEST.role)
                     it.anyRequest().permitAll()
                 }
 

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -1,9 +1,8 @@
 package site.hirecruit.hr.global.security
 
-import org.apache.tomcat.util.descriptor.web.SecurityRoleRef
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.context.support.BeanDefinitionDsl
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
@@ -38,6 +37,23 @@ class SecurityConfig(
             .logoutUrl("/api/v1/auth/logout")
             .logoutSuccessHandler(logoutSuccessHandler)
     }
+
+    private fun authorizeRequests(http: HttpSecurity){
+        http
+            .authorizeRequests{
+                it.antMatchers(
+                    "/api/v1/worker/me",
+                    "/api/v1/worker/me/**"
+                ).hasAnyRole(Role.UNAUTHENTICATED_EMAIL.name, Role.CLIENT.name)
+                it.antMatchers(
+                    "/api/v1/auth/registration"
+                ).hasRole(Role.GUEST.name)
+                it.antMatchers(HttpMethod.POST, "/api/v1/company")
+                    .authenticated()
+                it.anyRequest().permitAll()
+            }
+    }
+
     /**
      * 운영환경(prod)에서 활성화 되는 SecurityConfig
      *
@@ -52,18 +68,7 @@ class SecurityConfig(
                 .csrf().disable()
                 .headers().frameOptions().disable()
 
-            http
-                .authorizeRequests{
-                    it.antMatchers(
-                        "/api/v1/worker/me",
-                        "/api/v1/worker/me/**"
-                    ).hasAnyRole(Role.UNAUTHENTICATED_EMAIL.role, Role.CLIENT.role)
-                    it.antMatchers(
-                        "/api/v1/auth/registration"
-                    ).hasRole(Role.GUEST.role)
-                    it.anyRequest().permitAll()
-                }
-
+            authorizeRequests(http)
             logoutConfig(http)
 
             http
@@ -106,8 +111,8 @@ class SecurityConfig(
                 .antMatchers("/test/email").hasRole(Role.UNAUTHENTICATED_EMAIL.name)
                 .antMatchers("/test/client").hasRole(Role.CLIENT.name)
                 .antMatchers("/test/guest").hasRole(Role.GUEST.name)
-                .anyRequest().permitAll()
 
+            authorizeRequests(http)
             logoutConfig(http)
 
             http

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -55,7 +55,7 @@ class SecurityConfig(
                     it.antMatchers(
                         "/api/v1/worker/me",
                         "/api/v1/worker/me/**"
-                    ).authenticated()
+                    ).hasAnyRole(Role.UNAUTHENTICATED_EMAIL.role, Role.CLIENT.role)
                     it.anyRequest().permitAll()
                 }
 
@@ -90,7 +90,6 @@ class SecurityConfig(
         override fun configure(http: HttpSecurity) {
             http
                 .csrf().disable()
-                .headers().frameOptions().disable()
 
             http
                 .authorizeRequests()


### PR DESCRIPTION
## 개요
API에 대한 접근 권한을 설정했습니다.
- `/api/v1/worker/me` `/api/v1/worker/me/**` : `UNAUTHENTICATED_EMAIL`, `CLIENT` 접근가능
- `/api/v1/auth/registration` : GUEST만 접근가능
- POST `/api/v1/company` : 인증된 유저 모두 접근가능