### PR TITLE
HTTP Option method의 모든 요청을 permitAll로 지정

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -42,6 +42,7 @@ class SecurityConfig(
 
     private fun authorizeRequests(http: HttpSecurity) = http
             .authorizeRequests{
+                it.antMatchers(HttpMethod.OPTIONS, "/**").permitAll() // CORS를 위해 OPTION method는 모든 요청에 대해 권한없이 접근할 수 있다.
                 it.antMatchers(
                     "/api/v1/worker/me",
                     "/api/v1/worker/me/**"


### PR DESCRIPTION
## 문제 원인
CORS문제가 발생한 이유는 `/api/v1/auth/registration`경로의 모든 HTTP METHOD에 대해 permission check를 진행합니다 이로인해 생기는 문제 인 거 같아 해당 pr를 작성합니다.

## 해결방안
모든 url의 HTTP option method 접근 허용