### PR TITLE
staging 프로필은 github oauth test app을 사용하도록 변경

### DIFF
--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -17,7 +17,7 @@ server:
 
 spring:
   config:
-    import: classpath:oauth/github-oauth.yml
+    import: classpath:oauth/github-oauth-test.yml
 
   mvc:
     path match:


### PR DESCRIPTION
## 개요
제목과 같습니다.

이유는 테스트용 프로필인 staging프로필은 github oauth test app을 사용하도록 해야 합니다.

<img width="776" alt="CleanShot 2022-06-11 at 18 17 52@2x" src="https://user-images.githubusercontent.com/62932968/173181816-361107a2-3d01-454e-8b33-1a1aee0f4222.png">

