### PR TITLE
Logout 성공시 NPE뜨는 원인

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/handler/CustomLogoutSuccessHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/CustomLogoutSuccessHandler.kt
@@ -15,7 +15,7 @@ class CustomLogoutSuccessHandler(
     override fun onLogoutSuccess(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        authentication: Authentication
+        authentication: Authentication?
     ) {
         response.status = HttpServletResponse.SC_OK
         response.sendRedirect(redirectBaseUri)


### PR DESCRIPTION
## 개요
쿠키 문제로 세션에 등록되어 있지 않은 유저가 로그아웃 한다면 `LoginSuccessHandler#onLogoutSuccess`의 Authentication객체가 null인 현상이 있음 이 메서드를 nullable 한 변수로 변경함