### PR TITLE
Hotfix 회원가입 시 introduction의 length에 대한 제약조건 누락

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -3,6 +3,7 @@ package site.hirecruit.hr.domain.worker.dto
 import com.fasterxml.jackson.annotation.JsonGetter
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.querydsl.core.annotations.QueryProjection
+import org.hibernate.validator.constraints.Length
 import org.hibernate.validator.constraints.URL
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.validator.annoation.CompanyIsNotExistByCompanyId
@@ -10,6 +11,7 @@ import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
+import kotlin.math.max
 
 /**
  * Worker 도메인 DTO
@@ -24,6 +26,7 @@ class WorkerDto {
         @field:NotNull @field:Min(1) @field:CompanyIsNotExistByCompanyId
         val _companyId: Long?, // validation 을 사용하기 위해 추가
         val giveLink: String? = null,
+        @field:Length(min = 0, max = 35)
         val introduction: String? = null,
         val devYear: Int? = null,
         val position: String? = null,


### PR DESCRIPTION
## 개요
introduction의 길이는 35자까지 허용이 되어야 한다. Bean validation을 통해 dto에 제약조건 추가

#164 master에 먼저 push된 hotfix입니다.