### PR TITLE
세션식별 쿠키이름을 SESSION에서 HRSESSION으로 변경

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,6 +12,7 @@ server:
       cookie:
         domain: localhost
         max-age: 36000
+        name: HRSESSION
 
 spring:
   config:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,6 +13,7 @@ server:
         max-age: P1D # 1일
         secure: true
         same-site: none
+        name: HRSESSION
       timeout: 1440m # 1440분 = 1일
 
 spring:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -13,6 +13,7 @@ server:
         max-age: P1D # 1일
         secure: true
         same-site: none
+        name: HRSESSION
       timeout: 1440m # 1440분 = 1일
 
 spring:


### PR DESCRIPTION
## 개요
제목과 같습니다.

## 이유
Spring Session에서 생성하는 `SESSION`쿠키의 값은 두가지 역할이 있습니다.
1. 사용자 추적
   > 로그인 전 사용자를 판별하여 세션을 생성할 떄 사용됨
2. 세션 식별

`SESSION`쿠키는 2개의 역할을 가지고 있기 때문에 로그아웃을 진행해도 `2. 세션을 식별하는 'SESSION' 쿠키`는 제거되어도
`1. 사용자 추적을 맡고있는 SESSION`은 제거되지 않아 로그아웃시 `SESSION`쿠키가 남아있어 Frontend에서 식별할 수 없던 이슈가 있었습니다.

그러므로 2번 역할인 세션을 식별하는 쿠키의 이름을 `HRSESSION`으로 변경하여 이러한 문제를 해결하려합니다.

