### PR TITLE
Add logback-config target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,10 +38,10 @@ out/
 
 ### env file ###
 .env.**
+**/resources/logback
 
 ### Github OAuth property ###
 **/resources/oauth
 
 ### Aws property ###
 **/resources/aws
-**/resources/logback.xml

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -65,6 +65,7 @@ spring:
 logging:
   level:
     site.hirecruit.hr : info
+  config: classpath:logback/logback-prod.xml
 
 oauth2.login.success.redirect-base-uri: https://www.hirecruit.site
 hr.domain: hirecruit.site

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -72,6 +72,7 @@ logging:
   level:
     org.hibernate.type.descriptor.sql : trace
     site.hirecruit.hr : debug
+  config: classpath:logback/logback-staging.xml
 
 oauth2.login.success.redirect-base-uri: https://www.hirecruit.site
 hr.domain: hirecruit.site


### PR DESCRIPTION
## 개요
로그를 확인하는데 불편함이 있어 logback 을 staging, prod 환경을 나누어 구성했습니다.

* prod 환경의 로그는 aws cloudwatch `log group/HiRecruit-Prod-Backend-App-Logging-Group` 에 저장됩니다.
* staging 환경의 로그는 aws cloudwatch `log group/HiRecruit-Staging-Backend-App-Logging-Group` 에 저장됩니다.

## 이후에 할 일
- [ ] s3에 변경된 logback 업로드
- [ ] prod, staging error 알람 멘트를 달리하기
- [ ] ec2 스토리지 낮추기
