### PR TITLE
FIx userRegistrationDto validator 적용되지 않은 문제 해결

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/UserRegistrationDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/UserRegistrationDto.kt
@@ -9,10 +9,14 @@ import javax.validation.constraints.NotNull
 
 data class UserRegistrationDto(
     @field:NotBlank @field:Email
-    val email: String,
+    val _email: String?,
 
-    val name: String,
+    @field:NotBlank
+    var _name: String?,
 
     @field:JsonProperty("worker") @field:NotNull @field:Valid
     val workerDto: WorkerDto.Registration
-)
+){
+    val email get() = _email!!
+    val name get() = _name!!
+}

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
@@ -58,8 +58,8 @@ internal class UserRegistrationAspectTest{
 
         // given:: Aspect가 실행될 proxy
         val userRegistrationDto = UserRegistrationDto(
-            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
-            name = RandomString.make(5),
+            _email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            _name = RandomString.make(5),
             workerDto = WorkerDto.Registration(
                 _companyId = Random.nextLong(),
             )

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImplTest.kt
@@ -29,8 +29,8 @@ internal class UserRegistrationServiceImplTest{
         val userRegistrationServiceImpl = UserRegistrationServiceImpl(emailAuthenticationService, userRepository, publisher)
 
         val userRegistrationDto = UserRegistrationDto(
-            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
-            name = RandomString.make(5),
+            _email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            _name = RandomString.make(5),
             workerDto = WorkerDto.Registration(
                 _companyId = Random.nextLong()
             )
@@ -92,8 +92,8 @@ internal class UserRegistrationServiceImplTest{
         val userRegistrationServiceImpl = UserRegistrationServiceImpl(emailAuthenticationService, userRepository, publisher)
 
         val userRegistrationDto = UserRegistrationDto(
-            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
-            name = RandomString.make(5),    // UserRegistrationDto.email = null
+            _email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            _name = RandomString.make(5),    // UserRegistrationDto.email = null
             workerDto = WorkerDto.Registration(
                 _companyId = Random.nextLong(),
             )

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthenticationTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceWithoutEmailAuthenticationTest.kt
@@ -34,8 +34,8 @@ internal class UserRegistrationServiceWithoutEmailAuthenticationTest{
         val userRegistrationService = UserRegistrationServiceWithoutEmailAuthentication(userRepository, publisher)
 
         val userRegistrationDto = UserRegistrationDto(
-            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
-            name = RandomString.make(5),
+            _email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            _name = RandomString.make(5),
             workerDto = WorkerDto.Registration(
                 _companyId = Random.nextLong(),
             )
@@ -105,8 +105,8 @@ internal class UserRegistrationServiceWithoutEmailAuthenticationTest{
         val userRegistrationService = UserRegistrationServiceWithoutEmailAuthentication(userRepository, publisher)
 
         val userRegistrationDto = UserRegistrationDto(
-            email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
-            name = RandomString.make(5),    // UserRegistrationDto.email = null
+            _email = "${RandomString.make(5)}@${RandomString.make(5)}.${RandomString.make(3)}",
+            _name = RandomString.make(5),    // UserRegistrationDto.email = null
             workerDto = WorkerDto.Registration(
                 _companyId = Random.nextLong(),
             )


### PR DESCRIPTION
## 개요
userRegistrationDto에 Bean validator가 사용되도록 null able한 변수로 설정

### 관련 로그
```log
20220614T001649 http-nio-8080-exec-9 WARN o.s.w.s.m.s.DefaultHandlerExceptionResolver Resolved [org.springframework.http.converter.HttpMessageNotReadableException: JSON parse error: Instantiation of [simple type, class site.hirecruit.hr.domain.auth.dto.UserRegistrationDto] value failed for JSON property email due to missing (therefore NULL) value for creator parameter email which is a non-nullable type; nested exception is com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of [simple type, class site.hirecruit.hr.domain.auth.dto.UserRegistrationDto] value failed for JSON property email due to missing (therefore NULL) value for creator parameter email which is a non-nullable type<EOL> at [Source: (org.springframework.util.StreamUtils$NonClosingInputStream); line: 1, column: 44] (through reference chain: site.hirecruit.hr.domain.auth.dto.UserRegistrationDto["email"])]
```