### PR TITLE
Hotfix 잔류 쿠키 제거 전용 쿠키에 secure추가

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/handler/CustomLogoutSuccessHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/CustomLogoutSuccessHandler.kt
@@ -50,6 +50,7 @@ class CustomLogoutSuccessHandler(
     }
 
     private fun deleteCookie(cookie: Cookie){
+        cookie.secure = true
         cookie.maxAge = 0 // 쿠키 삭제하게 위해 maxAge 0으로 설정
     }
 


### PR DESCRIPTION
## 개요
삭제할 cookie에 secure옵션을 주지 않아 제거되지 않은 오류 해결 #175 