### PR TITLE
회원 등록 rollback service

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.kt
@@ -3,7 +3,7 @@ package site.hirecruit.hr.domain.auth.dto
 /**
  * Oauth2 클라이언트의 정보를 담고 있는 객체
  * ## notice
- * 해당 클래스는 생성자를 통해 객체를 생성할 수 없습니다. 대신 정적 팩토리 메서드([OAuthAttributes.of])를 사용해주세요
+ * 해당 클래스는 생성자를 통해 객체를 생성할 수 없습니다. 대신 정적 팩토리 메서드([OAuthAttributes.ofUserRollbackData])를 사용해주세요
  *
  * ### example
  * ```kotlin
@@ -25,6 +25,20 @@ class OAuthAttributes private constructor(
 ) {
 
     companion object {
+
+        /**
+         * user rollback에 사용되는 팩토리 메서드
+         */
+        fun ofUserRollbackData(rollbackAuthUserInfo: AuthUserInfo) =
+            OAuthAttributes(
+                attributes = emptyMap(),
+                userNameAttributeName = "id",
+                id = rollbackAuthUserInfo.githubId,
+                email = rollbackAuthUserInfo.email,
+                name = "임시유저",
+                profileImgUri = rollbackAuthUserInfo.profileImgUri
+            )
+
         fun of(
             registrationId : String,
             userNameAttributeName : String,

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
@@ -7,4 +7,6 @@ interface UserRepository : JpaRepository<UserEntity, Long>, UserCustomRepository
     fun existsByGithubId(githubId: Long) : Boolean
 
     fun findByGithubId(githubId: Long): UserEntity?
+
+    fun deleteByGithubId(githubId: Long)
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationRollbackService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationRollbackService.kt
@@ -1,0 +1,19 @@
+package site.hirecruit.hr.domain.auth.service
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+
+/**
+ * 회원 등록 트랜젝션 실패시 수행할 Rollback Service
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+interface UserRegistrationRollbackService {
+
+    /**
+     * 회원 등록 트렌젝션이 실패하면 회원 데이터를 rollback한다.
+     *
+     * @return rollback에 성공한 AuthUserInfo
+     */
+    fun rollback(rollbackUserInfo: AuthUserInfo): AuthUserInfo
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -1,0 +1,38 @@
+package site.hirecruit.hr.domain.auth.service.impl
+
+import org.springframework.stereotype.Service
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
+import site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService
+
+/**
+ * UserRegistrationRollbackService 구현체
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+@Service
+class UserRegistrationRollbackServiceImpl(
+    private val userRepository: UserRepository,
+    private val tempUserRegistrationService: TempUserRegistrationService
+): UserRegistrationRollbackService {
+
+    /**
+     * 회원 등록 트랜잭션이 실패 했을 떄 User데이터를 Rollback한다.
+     */
+    override fun rollback(rollbackUserInfo: AuthUserInfo): AuthUserInfo {
+        userRepository.deleteByGithubId(rollbackUserInfo.githubId)
+        val rollbackTempUserRegistrationData = OAuthAttributes.ofUserRollbackData(rollbackUserInfo)
+        tempUserRegistrationService.registration(rollbackTempUserRegistrationData) // 회원등록에 실패하였으므로 임시유저로 rollback
+        return AuthUserInfo(
+            githubId = rollbackUserInfo.githubId,
+            name = rollbackUserInfo.name,
+            email = rollbackUserInfo.email,
+            profileImgUri = rollbackUserInfo.profileImgUri,
+            role = Role.GUEST
+        )
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -22,6 +22,7 @@ class UserRegistrationRollbackServiceImpl(
 
     /**
      * 회원 등록 트랜잭션이 실패 했을 떄 User데이터를 Rollback한다.
+     * 일종의 SAGA Pattern의 보상 트랜잭션이다.
      */
     override fun rollback(rollbackUserInfo: AuthUserInfo): AuthUserInfo {
         userRepository.deleteByGithubId(rollbackUserInfo.githubId)


### PR DESCRIPTION
## 개요
회원 등록 Rollback Service를 만들었습니다.

## 만든 이유
결론부터 말하자면 SAGA패턴에서 보장 트랜잭션을 구현하려 해당 Service를 작성했습니다.

회원가입 절차는 `User생성`과 `Worker생성`의 각각의 작은 2개의 트랜잭션으로 이루어져 있습니다.
회원가입이 절차를 간단하게 설명하면 
1. User생성
2. User생성이 완료되면 `UserRegistrationEvent`가 발생하고,
3. `UserRegistrationEvent`가 발생하면 그 후 Worker가 생성이 됩니다.
> User생성 과 Worker생성 트랜잭션은 Spring Event로 각각 독립적으로 분리되어 있습니다.

`User생성`과 `Worker생성` 이 2개의 트랜잭션 중 어느 하나 실패하게 된다면 회원가입 절차는 실패해야 합니다. 
반대로 이 2개의 트랜젝션이 모두 성공하면 회원가입 절차는 성공해야 합니다. 즉 회원가입 절차는 원자성을 보장해야 합니다.

만약 `Worker생성`트랜잭션이 실패하게 된다면, `Worker생성` 이전단계인 `User생성` 트랜잭션을 통해 저장된 User는 제거되어
이렇게 회원가입 절차가 실패하면 이전 트랜잭션을 막기위한 또 다른 트랜젝션인 Rollback을 수행하게 되는데 이를 
SAGA패턴에서 보상 트랜잭션이라고 하는데 이를 구현하기 위해 회원등록을 rollback하는 서비스를 생성했습니다.