### PR TITLE
Feature/user rollback service

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspect.kt
@@ -4,7 +4,6 @@ import mu.KotlinLogging
 import org.aspectj.lang.annotation.AfterReturning
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Pointcut
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizedClientRepository
 import org.springframework.stereotype.Component
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.global.data.SessionAttribute
@@ -13,25 +12,28 @@ import javax.servlet.http.HttpSession
 private val log = KotlinLogging.logger {}
 
 /**
- * UserAuth관련 AOP
+ * session에 저장된 AuthUserInfo 저장 Aspect
  *
  * @author 정시원
  * @since 1.0
  */
 @Component
 @Aspect
-class UserAuthAspect (
+class UserSessionInfoUpdateAspect (
     private val httpSession: HttpSession
 ) {
 
     @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserAuthService+.authentication(..))")
     private fun userAuthService_AuthenticationMethodPointCut(){}
 
+    @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService+.rollback(..))")
+    private fun userRegistrationRollbackService_rollback(){}
+
     /**
      * [site.hirecruit.hr.domain.auth.service.UserAuthService.authentication]에서의 유저 인증 수행 후 세션을 발급하는 AOP method
      */
     @AfterReturning(
-        "userAuthService_AuthenticationMethodPointCut()",
+        "userAuthService_AuthenticationMethodPointCut() || userRegistrationRollbackService_rollback()",
         returning = "authUserInfo"
     )
     private fun setSessionByAuthUserInfo(authUserInfo: AuthUserInfo): Any{

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.kt
@@ -15,7 +15,7 @@ package site.hirecruit.hr.domain.auth.dto
  * ```
  * @author 정시원
  */
-class OAuthAttributes private constructor(
+data class OAuthAttributes private constructor(
     val attributes: Map<String, Any>,
     val userNameAttributeName: String,
     val id: Long,

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/OAuthAttributes.kt
@@ -3,7 +3,7 @@ package site.hirecruit.hr.domain.auth.dto
 /**
  * Oauth2 클라이언트의 정보를 담고 있는 객체
  * ## notice
- * 해당 클래스는 생성자를 통해 객체를 생성할 수 없습니다. 대신 정적 팩토리 메서드([OAuthAttributes.of])를 사용해주세요
+ * 해당 클래스는 생성자를 통해 객체를 생성할 수 없습니다. 대신 정적 팩토리 메서드([OAuthAttributes.ofUserRollbackData])를 사용해주세요
  *
  * ### example
  * ```kotlin
@@ -25,6 +25,20 @@ class OAuthAttributes private constructor(
 ) {
 
     companion object {
+
+        /**
+         * user rollback에 사용되는 팩토리 메서드
+         */
+        fun ofUserRollbackData(rollbackAuthUserInfo: AuthUserInfo) =
+            OAuthAttributes(
+                attributes = emptyMap(),
+                userNameAttributeName = "id",
+                id = rollbackAuthUserInfo.githubId,
+                email = rollbackAuthUserInfo.email,
+                name = "임시유저",
+                profileImgUri = rollbackAuthUserInfo.profileImgUri
+            )
+
         fun of(
             registrationId : String,
             userNameAttributeName : String,

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
@@ -7,4 +7,6 @@ interface UserRepository : JpaRepository<UserEntity, Long>, UserCustomRepository
     fun existsByGithubId(githubId: Long) : Boolean
 
     fun findByGithubId(githubId: Long): UserEntity?
+
+    fun deleteByGithubId(githubId: Long)
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationRollbackService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationRollbackService.kt
@@ -1,0 +1,19 @@
+package site.hirecruit.hr.domain.auth.service
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+
+/**
+ * 회원 등록 트랜젝션 실패시 수행할 Rollback Service
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+interface UserRegistrationRollbackService {
+
+    /**
+     * 회원 등록 트렌젝션이 실패하면 회원 데이터를 rollback한다.
+     *
+     * @return rollback에 성공한 AuthUserInfo
+     */
+    fun rollback(rollbackUserInfo: AuthUserInfo): AuthUserInfo
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -30,7 +30,7 @@ class UserRegistrationRollbackServiceImpl(
         tempUserRegistrationService.registration(rollbackTempUserRegistrationData) // 회원등록에 실패하였으므로 임시유저로 rollback
         return AuthUserInfo(
             githubId = rollbackUserInfo.githubId,
-            name = rollbackUserInfo.name,
+            name = "임시유저",
             email = rollbackUserInfo.email,
             profileImgUri = rollbackUserInfo.profileImgUri,
             role = Role.GUEST

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -1,0 +1,38 @@
+package site.hirecruit.hr.domain.auth.service.impl
+
+import org.springframework.stereotype.Service
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
+import site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService
+
+/**
+ * UserRegistrationRollbackService 구현체
+ *
+ * @author 정시원
+ * @since 1.0
+ */
+@Service
+class UserRegistrationRollbackServiceImpl(
+    private val userRepository: UserRepository,
+    private val tempUserRegistrationService: TempUserRegistrationService
+): UserRegistrationRollbackService {
+
+    /**
+     * 회원 등록 트랜잭션이 실패 했을 떄 User데이터를 Rollback한다.
+     */
+    override fun rollback(rollbackUserInfo: AuthUserInfo): AuthUserInfo {
+        userRepository.deleteByGithubId(rollbackUserInfo.githubId)
+        val rollbackTempUserRegistrationData = OAuthAttributes.ofUserRollbackData(rollbackUserInfo)
+        tempUserRegistrationService.registration(rollbackTempUserRegistrationData) // 회원등록에 실패하였으므로 임시유저로 rollback
+        return AuthUserInfo(
+            githubId = rollbackUserInfo.githubId,
+            name = rollbackUserInfo.name,
+            email = rollbackUserInfo.email,
+            profileImgUri = rollbackUserInfo.profileImgUri,
+            role = Role.GUEST
+        )
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -22,6 +22,7 @@ class UserRegistrationRollbackServiceImpl(
 
     /**
      * 회원 등록 트랜잭션이 실패 했을 떄 User데이터를 Rollback한다.
+     * 일종의 SAGA Pattern의 보상 트랜잭션이다.
      */
     override fun rollback(rollbackUserInfo: AuthUserInfo): AuthUserInfo {
         userRepository.deleteByGithubId(rollbackUserInfo.githubId)

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspectTest.kt
@@ -6,7 +6,6 @@ import net.bytebuddy.utility.RandomString
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
 import org.springframework.mock.web.MockHttpSession
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
@@ -16,7 +15,7 @@ import site.hirecruit.hr.domain.auth.service.UserAuthService
 import site.hirecruit.hr.global.data.SessionAttribute
 import kotlin.random.Random
 
-internal class UserAuthAspectTest{
+internal class UserSessionInfoUpdateAspectTest{
 
     private fun makeOAuth2Attributes() : OAuthAttributes {
         val attributes = mapOf<String, Any>(
@@ -49,7 +48,7 @@ internal class UserAuthAspectTest{
         val userAuthService: UserAuthService = mockk() // proxy
         val factory = AspectJProxyFactory(userAuthService)
         every { userAuthService.authentication(oAuth2Attributes) } answers { proxyReturnValue }
-        factory.addAspect(UserAuthAspect(httpSession))
+        factory.addAspect(UserSessionInfoUpdateAspect(httpSession))
         val proxy = factory.getProxy<UserAuthService>()
 
         // when

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
@@ -38,15 +38,15 @@ internal class UserRegistrationRollbackServiceImplTest{
         verify(exactly = 1) { userRepository.deleteByGithubId(afterRollbackAuthUserInfo.githubId) }
         verify(exactly = 1) { tempUserRegistrationService.registration(userRollbackDataOAuthAttributes) }
 
-        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 githubId, email, profileImgUri에 대해 같은 값을 가진다.", {
+        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 githubId, email, name, profileImgUri에 대해 같은 값을 가진다.", {
             assertEquals(beforeRollbackAuthUserInfo.githubId, afterRollbackAuthUserInfo.githubId)
             assertEquals(beforeRollbackAuthUserInfo.email, afterRollbackAuthUserInfo.email)
+            assertEquals(beforeRollbackAuthUserInfo.name, afterRollbackAuthUserInfo.name)
             assertEquals(beforeRollbackAuthUserInfo.profileImgUri, afterRollbackAuthUserInfo.profileImgUri)
         })
 
-        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 role, name에 대해 다른 값을 가진다.", {
+        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 role에 대해 다른 값을 가진다.", {
             assertNotEquals(afterRollbackAuthUserInfo.role, beforeRollbackAuthUserInfo.role)
-            assertNotEquals(afterRollbackAuthUserInfo.name, beforeRollbackAuthUserInfo.name)
         })
 
         assertAll("롤백 후 AuthUserInfo의 name=\"임시유저\" role=GUEST를 만족해야 한다.", {

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
@@ -38,15 +38,15 @@ internal class UserRegistrationRollbackServiceImplTest{
         verify(exactly = 1) { userRepository.deleteByGithubId(afterRollbackAuthUserInfo.githubId) }
         verify(exactly = 1) { tempUserRegistrationService.registration(userRollbackDataOAuthAttributes) }
 
-        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 githubId, email, name, profileImgUri에 대해 같은 값을 가진다.", {
+        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 githubId, email, profileImgUri에 대해 같은 값을 가진다.", {
             assertEquals(beforeRollbackAuthUserInfo.githubId, afterRollbackAuthUserInfo.githubId)
             assertEquals(beforeRollbackAuthUserInfo.email, afterRollbackAuthUserInfo.email)
-            assertEquals(beforeRollbackAuthUserInfo.name, afterRollbackAuthUserInfo.name)
             assertEquals(beforeRollbackAuthUserInfo.profileImgUri, afterRollbackAuthUserInfo.profileImgUri)
         })
 
-        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 role에 대해 다른 값을 가진다.", {
+        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 role, name에 대해 다른 값을 가진다.", {
             assertNotEquals(afterRollbackAuthUserInfo.role, beforeRollbackAuthUserInfo.role)
+            assertNotEquals(afterRollbackAuthUserInfo.name, beforeRollbackAuthUserInfo.name)
         })
 
         assertAll("롤백 후 AuthUserInfo의 name=\"임시유저\" role=GUEST를 만족해야 한다.", {

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
@@ -1,0 +1,57 @@
+package site.hirecruit.hr.domain.auth.service.impl
+
+import io.mockk.*
+import net.bytebuddy.utility.RandomString
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
+import kotlin.random.Random
+
+internal class UserRegistrationRollbackServiceImplTest{
+
+    private val userRepository: UserRepository = mockk()
+    private val tempUserRegistrationService: TempUserRegistrationService = mockk()
+
+    private val userRegistrationRollbackServiceImpl = UserRegistrationRollbackServiceImpl(this.userRepository, this.tempUserRegistrationService)
+
+
+    @Test
+    internal fun rollbackTest(){
+        val beforeRollbackAuthUserInfo = AuthUserInfo(
+            githubId = Random.nextLong(),
+            name = RandomString.make(5),
+            email = RandomString.make(10),
+            profileImgUri = RandomString.make(10),
+            Role.CLIENT
+        )
+        val userRollbackDataOAuthAttributes = OAuthAttributes.ofUserRollbackData(beforeRollbackAuthUserInfo)
+
+        every { userRepository.deleteByGithubId(beforeRollbackAuthUserInfo.githubId) } just runs
+        every { tempUserRegistrationService.registration(userRollbackDataOAuthAttributes) } just runs
+
+        val afterRollbackAuthUserInfo = userRegistrationRollbackServiceImpl.rollback(beforeRollbackAuthUserInfo)
+
+        verify(exactly = 1) { userRepository.deleteByGithubId(afterRollbackAuthUserInfo.githubId) }
+        verify(exactly = 1) { tempUserRegistrationService.registration(userRollbackDataOAuthAttributes) }
+
+        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 githubId, email, profileImgUri에 대해 같은 값을 가진다.", {
+            assertEquals(beforeRollbackAuthUserInfo.githubId, afterRollbackAuthUserInfo.githubId)
+            assertEquals(beforeRollbackAuthUserInfo.email, afterRollbackAuthUserInfo.email)
+            assertEquals(beforeRollbackAuthUserInfo.profileImgUri, afterRollbackAuthUserInfo.profileImgUri)
+        })
+
+        assertAll("롤백 전 AuthUserInfo와 롤백 후 AuthUserInfo는 role, name에 대해 다른 값을 가진다.", {
+            assertNotEquals(afterRollbackAuthUserInfo.role, beforeRollbackAuthUserInfo.role)
+            assertNotEquals(afterRollbackAuthUserInfo.name, beforeRollbackAuthUserInfo.name)
+        })
+
+        assertAll("롤백 후 AuthUserInfo의 name=\"임시유저\" role=GUEST를 만족해야 한다.", {
+            assertEquals("임시유저", afterRollbackAuthUserInfo.name)
+            assertEquals(Role.GUEST, afterRollbackAuthUserInfo.role)
+        })
+    }
+}


### PR DESCRIPTION
## 개요
회원 등록 Rollback Service를 만들었습니다.

### 로직 설명
회원의 정보를 회원가입 전으로 롤백합니다. 즉 임시 유저 상태로 되돌립니다.

### 만든 이유
결론부터 말하자면 SAGA패턴에서 보장 트랜잭션을 구현하기 위해 해당 Service를 작성했습니다.

회원가입 절차는 `User생성`과 `Worker생성`의 각각의 작은 2개의 트랜잭션으로 이루어져 있습니다.
회원가입이 절차를 간단하게 설명하면 
1. `User생성` 트랜잭션이 시작하면 `UserRegistrationEvent`가 발생합니다.
2. `User생성` 르랜잭션이 커밋 된 후 `Worker생성` 트랜잭션이 수행됩니다.
3. `UserRegistrationEvent`가 발생하면 그 후 Worker가 생성이 됩니다.
> `User생성` 과 `Worker생성` 트랜잭션은 Spring Event로 각각 독립적으로 분리되어 있습니다.

`User생성`과 `Worker생성` 이 2개의 트랜잭션 중 어느 하나 실패하게 된다면 회원가입 절차는 실패해야 합니다. 
반대로 이 2개의 트랜잭션이 모두 성공하면 회원가입 절차는 성공해야 합니다. 즉 회원가입 절차는 원자성을 보장해야 합니다.

만약 `Worker생성`트랜잭션이 실패하게 된다면, 서버는 `Worker생성` 이전 단계인 `User생성` 트랜잭션을 수행하기 전으로 복구해야 합니다.

이렇게 오류에 대한 복구(보상)를 진행한다는 의미로 SAGA패턴에서 보상 트랜잭션이라고 하는데 이를 구현하기 위해 회원등록을 rollback하는 서비스를 생성했습니다.