### PR TITLE
/auth/registration 호출시 USER_TYPE 쿠키에 사용자 role 반환

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
@@ -1,5 +1,6 @@
 package site.hirecruit.hr.domain.auth.controller
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -7,13 +8,17 @@ import site.hirecruit.hr.domain.auth.service.UserRegistrationService
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
+import site.hirecruit.hr.global.util.CookieMakerUtil
 import springfox.documentation.annotations.ApiIgnore
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 
 @RestController
 @RequestMapping("/api/v1/auth")
 class AuthController(
-    private val userRegistrationService: UserRegistrationService
+    private val userRegistrationService: UserRegistrationService,
+    @Value("\${hr.domain}") private val hrDomain: String
 ) {
 
     @PostMapping("/registration")
@@ -22,9 +27,13 @@ class AuthController(
         authUserInfo: AuthUserInfo,
 
         @RequestBody  @Valid
-        userRegistrationDto: UserRegistrationDto
+        userRegistrationDto: UserRegistrationDto,
+
+        response: HttpServletResponse
     ): ResponseEntity<AuthUserInfo>{
         val registeredAuthUserInfo = userRegistrationService.registration(authUserInfo, userRegistrationDto)
+
+        response.addCookie(CookieMakerUtil.userTypeCookie(registeredAuthUserInfo.role.name, hrDomain)) // 등록된 유저의 role을 USER_TYPE 쿠키로 넘겨줌
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(registeredAuthUserInfo)
     }

--- a/src/main/java/site/hirecruit/hr/global/util/CookieMakerUtil.kt
+++ b/src/main/java/site/hirecruit/hr/global/util/CookieMakerUtil.kt
@@ -1,0 +1,25 @@
+package site.hirecruit.hr.global.util
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import javax.servlet.http.Cookie
+
+/**
+ * cookie 생성 util class
+ *
+ * @author 정시원
+ * @since 1.1.1
+ */
+@Component
+class CookieMakerUtil{
+
+    companion object{
+        fun userTypeCookie(value: String, hrDomain: String): Cookie{
+            val userTypeCookie = Cookie("USER_TYPE", value)
+            userTypeCookie.maxAge = 86400
+            userTypeCookie.path = "/"
+            userTypeCookie.domain = hrDomain
+            return userTypeCookie
+        }
+    }
+}


### PR DESCRIPTION
## 개요
클라이언트에서 사용자를 판별하는 USER_TYPE 쿠키에 registration이 수행된 후 실행되는 USER에 대한 role를 반환합니다.

`/api/v1/auth/registration` API문서를 확인해주세요
https://www.notion.so/jyeonjyan/HiRecruit-HR-9ac7019a727b41ba95cf482d784c780d