### PR TITLE
redis에서 관리하던 TempUser를 mysql에서 관리

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
@@ -1,18 +1,19 @@
 package site.hirecruit.hr.domain.auth.entity
 
-import org.springframework.data.annotation.Id
-import org.springframework.data.redis.core.RedisHash
 import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Id
+import javax.persistence.Table
+
 /**
  * 임시 유저를 저장하는 Entity
- * Redis namespace는 temp_user를 사용하고 1시간의 유효기간을 갖습니다.
  *
  * @author 정시원
  */
-@RedisHash(value = "temp_user", timeToLive = 60 * 60)
+@Entity @Table(name = "temp_user")
 class TempUserEntity(
-    @Id
-    @Column(name = "github_id")
+
+    @Id @Column(name = "github_id")
     val githubId: Long,
 
     @Column(name = "profile_uri")
@@ -20,7 +21,7 @@ class TempUserEntity(
 ) {
 
     @javax.persistence.Transient
-    var role = Role.GUEST // 임시 유저의 권한은 GUEST이다.
+    final var role = Role.GUEST // 임시 유저의 권한은 GUEST이다.
         private set
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/TempUserEntity.kt
@@ -19,10 +19,6 @@ class TempUserEntity(
     @Column(name = "profile_uri")
     val profileImgUri: String,
 ) {
-
-    @javax.persistence.Transient
-    final var role = Role.GUEST // 임시 유저의 권한은 GUEST이다.
-        private set
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is TempUserEntity) return false

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserAuthService
@@ -46,7 +47,7 @@ open class UserSessionAuthServiceImpl(
             githubId = tempUserEntity.githubId,
             name = "임시유저",
             email = null,
-            role = tempUserEntity.role,
+            role = Role.GUEST,
             profileImgUri = tempUserEntity.profileImgUri
         )
     }


### PR DESCRIPTION
## 개요
임시유저는 redis로 관리되어 있고 TTL를 사용하여 유효기간을 설정했지만 관리하기 까다로워 MySQL로 이전합니다.