### PR TITLE
회원가입시 저장되는 회원의 url UNAUTHENTICATED_EMAIL에서 WORKER로 변경

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -39,7 +39,7 @@ class UserRegistrationServiceImpl(
             email = userRegistrationInfo.email,
             name = userRegistrationInfo.name,
             profileImgUri = authUserInfo.profileImgUri,
-            Role.UNAUTHENTICATED_EMAIL
+            Role.WORKER
         )
         val savedUserEntity = userRepository.save(userEntity)
         val registrationAuthUserInfo = AuthUserInfo(


### PR DESCRIPTION
## 개요
제목과 같습니다.

### 앞으로 해야할 일
 해당 분기가 master에 올라가기 전에 DB에 저장되어 있는 `UNAUTHENTICATED_EMAIL` 값을 모두 `WORKER`로 변경해야 합니다.