### PR TITLE
WorkerRegistration트랜잭션 실패시 보상 트랜잭션 발생 로직 작성

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -1,6 +1,8 @@
 package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.entity.Role
@@ -24,6 +26,7 @@ class UserRegistrationRollbackServiceImpl(
      * 회원 등록 트랜잭션이 실패 했을 떄 User데이터를 Rollback한다.
      * 일종의 SAGA Pattern의 보상 트랜잭션이다.
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     override fun rollback(rollbackUserInfo: AuthUserInfo): AuthUserInfo {
         userRepository.deleteByGithubId(rollbackUserInfo.githubId)
         val rollbackTempUserRegistrationData = OAuthAttributes.ofUserRollbackData(rollbackUserInfo)

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
@@ -1,6 +1,7 @@
 package site.hirecruit.hr.domain.worker.service
 
 import mu.KotlinLogging
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
@@ -12,6 +13,7 @@ import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository
+import site.hirecruit.hr.global.event.WorkerRegistrationEvent
 
 val log = KotlinLogging.logger {}
 
@@ -25,11 +27,13 @@ val log = KotlinLogging.logger {}
 class WorkerRegistrationServiceImpl(
     private val userRepository: UserRepository,
     private val workerRepository: WorkerRepository,
-    private val companyRepository: CompanyRepository
+    private val companyRepository: CompanyRepository,
+    private val publisher: ApplicationEventPublisher
 ): WorkerRegistrationService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     override fun registration(authUserInfo: AuthUserInfo, registrationDto: WorkerDto.Registration): WorkerDto.Info{
+        publisher.publishEvent(WorkerRegistrationEvent(authUserInfo))
         val userEntity = userRepository.findByGithubId(authUserInfo.githubId)
             ?: throw IllegalStateException("Cannot found UserEntity, githubId='${authUserInfo.githubId}'")
         val companyEntity = companyRepository.findByIdOrNull(registrationDto.companyId)

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
@@ -33,7 +33,7 @@ class WorkerRegistrationServiceImpl(
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     override fun registration(authUserInfo: AuthUserInfo, registrationDto: WorkerDto.Registration): WorkerDto.Info{
-        publisher.publishEvent(WorkerRegistrationEvent(authUserInfo))
+        publisher.publishEvent(WorkerRegistrationEvent(authUserInfo, registrationDto))
         val userEntity = userRepository.findByGithubId(authUserInfo.githubId)
             ?: throw IllegalStateException("Cannot found UserEntity, githubId='${authUserInfo.githubId}'")
         val companyEntity = companyRepository.findByIdOrNull(registrationDto.companyId)

--- a/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEvent.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEvent.kt
@@ -7,6 +7,7 @@ import site.hirecruit.hr.domain.worker.dto.WorkerDto
  * WorkerRegistration Event객체
  *
  * @see site.hirecruit.hr.domain.worker.service.WorkerRegistrationService
+ * @see WorkerRegistrationEventHandler
  * @author 정시원
  * @since 1.1.2
  */

--- a/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEvent.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEvent.kt
@@ -1,13 +1,16 @@
 package site.hirecruit.hr.global.event
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.worker.dto.WorkerDto
 
 /**
  * WorkerRegistration Event객체
  *
- *@see site.hirecruit.hr.domain.worker.service.WorkerRegistrationService
+ * @see site.hirecruit.hr.domain.worker.service.WorkerRegistrationService
  * @author 정시원
+ * @since 1.1.2
  */
 data class WorkerRegistrationEvent(
-    val authUserInfo: AuthUserInfo
+    val authUserInfo: AuthUserInfo,
+    val workerRegistrationDto: WorkerDto.Registration
 )

--- a/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEvent.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEvent.kt
@@ -1,0 +1,13 @@
+package site.hirecruit.hr.global.event
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+
+/**
+ * WorkerRegistration Event객체
+ *
+ *@see site.hirecruit.hr.domain.worker.service.WorkerRegistrationService
+ * @author 정시원
+ */
+data class WorkerRegistrationEvent(
+    val authUserInfo: AuthUserInfo
+)

--- a/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEventHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/event/WorkerRegistrationEventHandler.kt
@@ -1,0 +1,40 @@
+package site.hirecruit.hr.global.event
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService
+
+private val log = KotlinLogging.logger {  }
+
+/**
+ * WorkerRegistrationEvent의 핸들러
+ * @author 정시원
+ * @since 1.1.2
+ */
+@Component
+class WorkerRegistrationEventHandler(
+    private val userRegistrationRollbackService: UserRegistrationRollbackService
+) {
+
+    /**
+     * Worker생성 트랜젝션이 실패하여 이에 대한 보상 트랜잭션을 수행하는 메서드
+     */
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    fun workerRegistrationFailHandler(workerRegistrationEvent: WorkerRegistrationEvent){
+        log.error {
+            """
+                직장인(worker)등록이 실패하였습니다. 보상 트랜잭션을 수행합니다.
+                error data: 
+                AuthUserInfo = '${workerRegistrationEvent.authUserInfo}'
+                WorkerRegistrationDto = '${workerRegistrationEvent.workerRegistrationDto}'
+            """.trimIndent()
+        }
+        log.info("WorkerRegistration에 대한 보상 트랜잭션을 수행합니다.")
+
+        val rollbackSuccessUserInfo = userRegistrationRollbackService.rollback(workerRegistrationEvent.authUserInfo)
+
+        log.info("WorkerRegistration에 대한 보상 트랜잭션이 완료되었습니다. RollbackUserInfo = '${rollbackSuccessUserInfo}'")
+    }
+}

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
@@ -24,7 +24,7 @@ internal class WorkerRegistrationServiceImplTest{
     private val userRepository: UserRepository = mockk()
     private val workerRepository: WorkerRepository = mockk()
     private val companyRepository: CompanyRepository = mockk()
-    private val workerRegistrationService = WorkerRegistrationServiceImpl(userRepository, workerRepository, companyRepository)
+    private val workerRegistrationService = WorkerRegistrationServiceImpl(userRepository, workerRepository, companyRepository, mockk(relaxed = true))
 
     @Test @DisplayName("Worker Registration test")
     fun workerRegistrationTest(){


### PR DESCRIPTION
## 개요
WorkerRegistrationEvent가 실패하게 된다면 앞에 수행된 UserRegistration트랜잭션을 복구하는 로직을 작성했습니다.
복구 방법은 저장된 User를 제거하고, 다시 임시유저로 등록합니다.