### PR TITLE
유저 인증 실패 핸들러

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package site.hirecruit.hr.global.security
 
+import mu.KotlinLogging
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpMethod
@@ -9,12 +10,14 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
 import org.springframework.security.oauth2.core.user.OAuth2User
-import org.springframework.security.web.access.AccessDeniedHandler
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
 import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.global.data.ServerProfile
+
+private val log = KotlinLogging.logger {  }
 
 /**
  * SecurityConfig
@@ -29,6 +32,7 @@ class SecurityConfig(
     private val oauth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
     private val authenticationSuccessHandler: AuthenticationSuccessHandler,
     private val logoutSuccessHandler: LogoutSuccessHandler,
+    private val authenticationFailureHandler: AuthenticationFailureHandler
 ) {
 
     private val oauth2LoginEndpointBaseUri = "/api/v1/auth/oauth2/authorization"
@@ -74,6 +78,7 @@ class SecurityConfig(
                 redirectEndPoint.baseUri(oauth2LoginRedirectionEndpointBaseUri)
             }
             oauth2Login.successHandler(authenticationSuccessHandler)
+            oauth2Login.failureHandler(authenticationFailureHandler)
         }
 
 

--- a/src/main/java/site/hirecruit/hr/global/security/handler/CustomAuthenticationFailureHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/CustomAuthenticationFailureHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.security.web.authentication.AuthenticationFailureHand
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerExceptionResolver
 import org.springframework.web.util.UriComponentsBuilder
+import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
@@ -23,7 +24,8 @@ private val log = KotlinLogging.logger {  }
 @Component
 class CustomAuthenticationFailureHandler(
     @Value("\${oauth2.login.success.redirect-base-uri}") val redirectBaseUri: String,
-    @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver
+    @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver,
+    @Value("\${server.servlet.session.cookie.domain}") val cookieDomain: String
 ): AuthenticationFailureHandler {
 
     /**
@@ -40,6 +42,7 @@ class CustomAuthenticationFailureHandler(
         exception: AuthenticationException
     ) {
         val redirectUriBuilder = UriComponentsBuilder.fromUriString(redirectBaseUri)
+        response.addCookie(setDeleteHrsessionCookie()) // OAuth2 login 실패시 HRSESSION제거
         if(exception is OAuth2AuthenticationException){ // OAuth2 로그인 예외라면
             log.debug { "OAuth2AuthenticationException error code = '${exception.error.errorCode}'" }
             oAuth2AuthenticationExceptionHandling(request, response, exception)
@@ -65,5 +68,16 @@ class CustomAuthenticationFailureHandler(
                 .build().toUriString()
         )
     }
+
+    private fun setDeleteHrsessionCookie(): Cookie{
+        val hrsessionCookie = Cookie("HRSESSION", null)
+        hrsessionCookie.secure = true
+        hrsessionCookie.maxAge = 0 // 쿠키 삭제하게 위해 maxAge 0으로 설정
+        hrsessionCookie.isHttpOnly = true
+        hrsessionCookie.domain = cookieDomain
+        hrsessionCookie.path = "/"
+        return hrsessionCookie
+    }
+
 
 }

--- a/src/main/java/site/hirecruit/hr/global/security/handler/CustomAuthenticationFailureHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/CustomAuthenticationFailureHandler.kt
@@ -1,0 +1,69 @@
+package site.hirecruit.hr.global.security.handler
+
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerExceptionResolver
+import org.springframework.web.util.UriComponentsBuilder
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+private val log = KotlinLogging.logger {  }
+
+/**
+ * Security 인증 실패 핸들러
+ *
+ * @author 정시원
+ * @since 1.1.2
+ */
+@Component
+class CustomAuthenticationFailureHandler(
+    @Value("\${oauth2.login.success.redirect-base-uri}") val redirectBaseUri: String,
+    @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver
+): AuthenticationFailureHandler {
+
+    /**
+     * Authentication 실패시 예외를 핸들링 하는 메서드
+     * OAuth2 인증 예외라면 [SecurityExceptionHandler.oauth2AuthenticationException]에서 예외를 헨들링한다.
+     * 에외처리는 Hirecruit GET /api/v1/auth/oauth2/authorization/github API 명세를 확인해주세요
+     *
+     * @see SecurityExceptionHandler.oauth2AuthenticationException
+     * @param exception Authentication실패에 대한 예외
+     */
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AuthenticationException
+    ) {
+        val redirectUriBuilder = UriComponentsBuilder.fromUriString(redirectBaseUri)
+        if(exception is OAuth2AuthenticationException){ // OAuth2 로그인 예외라면
+            log.debug { "OAuth2AuthenticationException error code = '${exception.error.errorCode}'" }
+            oAuth2AuthenticationExceptionHandling(request, response, exception)
+        } else{
+            unknownExceptionHandling(response, redirectUriBuilder)
+            log.error(exception){ "Unknown Authentication Exception"}
+        }
+    }
+
+    private fun oAuth2AuthenticationExceptionHandling(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        ex: OAuth2AuthenticationException
+    ){
+        resolver.resolveException(request, response, null, ex)
+    }
+
+    private fun unknownExceptionHandling(response: HttpServletResponse, redirectUrlBuilder: UriComponentsBuilder){
+        response.sendRedirect(
+            redirectUrlBuilder
+                .queryParam("login", "fail")
+                .queryParam("server_error", true)
+                .build().toUriString()
+        )
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
@@ -1,11 +1,19 @@
 package site.hirecruit.hr.global.security.handler
 
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes
 import org.springframework.security.web.firewall.RequestRejectedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.util.UriComponentsBuilder
 import site.hirecruit.hr.global.exception.model.ExceptionResponseEntity
+import javax.servlet.http.HttpServletResponse
+
+private val log = KotlinLogging.logger {  }
 
 /**
  * Security관련 exception handler
@@ -14,7 +22,9 @@ import site.hirecruit.hr.global.exception.model.ExceptionResponseEntity
  * @since 1.0
  */
 @RestControllerAdvice
-class SecurityExceptionHandler {
+class SecurityExceptionHandler(
+    @Value("\${oauth2.login.success.redirect-base-uri}") val redirectBaseUri: String,
+) {
 
     /**
      * Spring Security Firewall에 의해 block된 요청을 헨들링 하는 메서드
@@ -25,4 +35,29 @@ class SecurityExceptionHandler {
     private fun requestRejectedException(requestRejectedException: RequestRejectedException): ResponseEntity<ExceptionResponseEntity> =
         ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
             .body(ExceptionResponseEntity(requestRejectedException.localizedMessage))
+
+    /**
+     * Oauth2 인증이 실패할 떄 발생하는 exception
+     */
+    @ExceptionHandler(OAuth2AuthenticationException::class)
+    private fun oauth2AuthenticationException(
+        ex: OAuth2AuthenticationException,
+        response: HttpServletResponse
+    ) {
+        val redirectUrlBuilder = UriComponentsBuilder.fromUriString(redirectBaseUri)
+        log.debug { "Oauth2AuthenticationExceptionHandler Active" }
+        when(ex.error.errorCode){
+            OAuth2ErrorCodes.ACCESS_DENIED -> { // 유저가 Oauth2 login동의를 하지 않을 때
+                log.info { "OAuth2ErrorCodes.${OAuth2ErrorCodes.ACCESS_DENIED}"}
+                redirectUrlBuilder.queryParam("login", "cancel")
+            }
+            else -> {
+                log.error { "예외 처리하지 않은 OAuth2 Exception 발생" } //
+                redirectUrlBuilder.queryParam("login", "fail")
+                redirectUrlBuilder.queryParam("server_error", true)
+            }
+        }
+        response.sendRedirect(redirectUrlBuilder.build().toUriString())
+    }
+
 }


### PR DESCRIPTION
## 개요
OAuth2인증과 같이 유저가 인증에 실패한다면 이에 대한 핸들러를 작성했습니다. 

이전에는 소셜로그인 인증 실패시 이에 대한 예외처리가 안되어 white lable page로 이동하던 오류가 있었습니다. 이를 프론트엔드 사이트로 이동하여 해당 문제를 해결했습니다.

### 해당 PR로 인한 bug fix
![CleanShot 2022-06-17 at 10 52 43](https://user-images.githubusercontent.com/62932968/174206696-bc715835-3ee2-4115-af1e-ced9cdc1340b.png)

깃허브 소셜로그인 동의페이지에서 cancel를 누르면 white lable page로 이동하는 버그 해결

