### PR TITLE
Fix 401, 403 error에 대한 cors에러

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
 import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.security.web.authentication.HttpStatusEntryPoint
@@ -32,7 +33,8 @@ class SecurityConfig(
     private val oauth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
     private val authenticationSuccessHandler: AuthenticationSuccessHandler,
     private val logoutSuccessHandler: LogoutSuccessHandler,
-    private val authenticationFailureHandler: AuthenticationFailureHandler
+    private val authenticationFailureHandler: AuthenticationFailureHandler,
+    private val authenticationEntryPoint: AuthenticationEntryPoint
 ) {
 
     private val oauth2LoginEndpointBaseUri = "/api/v1/auth/oauth2/authorization"
@@ -62,8 +64,13 @@ class SecurityConfig(
     private fun accessDenied(http: HttpSecurity){
         http
             .exceptionHandling {
-                it.authenticationEntryPoint(HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+//                it.accessDeniedHandler()
+                it.authenticationEntryPoint(authenticationEntryPoint)
             }
+    }
+
+    private fun cors(http: HttpSecurity){
+        http.cors()
     }
 
     private fun oauth2Login(http: HttpSecurity) =
@@ -95,6 +102,7 @@ class SecurityConfig(
             http
                 .csrf().disable()
 
+            cors(http)
             authorizeRequests(http)
             logoutConfig(http)
             accessDenied(http)
@@ -112,6 +120,8 @@ class SecurityConfig(
     @Profile(ServerProfile.DEFAULT, ServerProfile.LOCAL, ServerProfile.STAGING)
     inner class TestingRole: WebSecurityConfigurerAdapter(){
         override fun configure(http: HttpSecurity) {
+            cors(http)
+
             http
                 .csrf().disable()
                 .headers().frameOptions().disable()

--- a/src/main/java/site/hirecruit/hr/global/security/handler/CustomAuthenticationEntryPoint.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/CustomAuthenticationEntryPoint.kt
@@ -1,0 +1,23 @@
+package site.hirecruit.hr.global.security.handler
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerExceptionResolver
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@Component
+class CustomAuthenticationEntryPoint(
+    @Qualifier("handlerExceptionResolver") private val resolver: HandlerExceptionResolver
+): AuthenticationEntryPoint {
+
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        resolver.resolveException(request, response, null, authException)
+    }
+}

--- a/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
@@ -4,6 +4,7 @@ import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.AuthenticationException
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes
 import org.springframework.security.web.firewall.RequestRejectedException
@@ -35,6 +36,11 @@ class SecurityExceptionHandler(
     private fun requestRejectedException(requestRejectedException: RequestRejectedException): ResponseEntity<ExceptionResponseEntity> =
         ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
             .body(ExceptionResponseEntity(requestRejectedException.localizedMessage))
+
+    @ExceptionHandler(AuthenticationException::class)
+    private fun authenticationException(authenticationException: AuthenticationException): ResponseEntity<ExceptionResponseEntity> =
+        ResponseEntity.status(HttpStatus.UNAUTHORIZED.value())
+            .body(ExceptionResponseEntity.of(authenticationException))
 
     /**
      * Oauth2 인증이 실패할 떄 발생하는 exception


### PR DESCRIPTION
## 개요
Spring Security에서 인증/인가 오류는 spring config에서 `http.cors()`를 설정 해줘야 SpringMVC의 cors설정을 사용할 수 있다.
이를 설정 한 후 좀 더 체계적으로 관리하기 위해 `CustomAuthenticationEntryPoint`를 만들어 등록하였다.