### PR TITLE
Feature/grant-mentor [Role 을 worker -> mentor]

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
@@ -23,11 +23,15 @@ class UserEntity(
     val profileImgUri: String,
 
     @Column(name = "role", nullable = false) @Enumerated(EnumType.STRING)
-    val role: Role
+    private var role: Role
 ) {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val userId: Long? = null
+
+    fun updateRole(role: Role){
+        this.role = role
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
@@ -23,7 +23,7 @@ class UserEntity(
     val profileImgUri: String,
 
     @Column(name = "role", nullable = false) @Enumerated(EnumType.STRING)
-    private var role: Role
+    var role: Role
 ) {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorService.kt
@@ -1,4 +1,6 @@
 package site.hirecruit.hr.domain.mentor.service
 
 interface MentorService {
+    fun mentorPromotionProcess(workerId: Long) : Map<Long, String>
+    fun grantMentorRole(workerId: Long) : String
 }

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorService.kt
@@ -2,5 +2,5 @@ package site.hirecruit.hr.domain.mentor.service
 
 interface MentorService {
     fun mentorPromotionProcess(workerId: Long) : Map<Long, String>
-    fun grantMentorRole(workerId: Long) : String
+    fun grantMentorRole(workerId: Long, verificationCode: String) : Long
 }

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
@@ -17,6 +17,9 @@ class MentorServiceImpl(
     /**
      * worker -> mentor 로의 승격절차를 밟는다.
      * 연락수단에 대해 인증을 요청한다.
+     *
+     * @param workerId mentor로 승격하고 싶은 workerId
+     * @return workerId : verificationCode
      */
     override fun mentorPromotionProcess(workerId: Long): Map<Long, String> {
         // 현재 worker가 맞는지 verify

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
@@ -1,4 +1,40 @@
 package site.hirecruit.hr.domain.mentor.service
 
-class MentorServiceImpl : MentorService {
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import site.hirecruit.hr.domain.mentor.verify.service.MentorVerificationService
+import site.hirecruit.hr.domain.worker.repository.WorkerRepository
+
+@Service
+class MentorServiceImpl(
+    private val workerRepository: WorkerRepository,
+    private val mentorVerificationServiceImpl: MentorVerificationService
+) : MentorService {
+
+    /**
+     * worker -> mentor 로의 승격절차를 밟는다.
+     * 연락수단에 대해 인증을 요청한다.
+     */
+    override fun mentorPromotionProcess(workerId: Long): Map<Long, String> {
+        // 현재 worker가 맞는지 verify
+        val workerEntity = (workerRepository.findByIdOrNull(workerId)
+            ?: throw Exception("workerId: $workerId 에 해당하는 worker를 찾을 수 없음"))
+
+        val sentVerificationCode = mentorVerificationServiceImpl.sendVerificationCode(
+            workerEntity.workerId!!,
+            workerEntity.user.email,
+            workerEntity.user.name
+        )
+
+        return mapOf(workerEntity.workerId!! to sentVerificationCode)
+    }
+
+    /**
+     * HR의 적합한 mentor 승격 절차를 밟아 역할을 worker -> mentor 업데이트한다.
+     * 연락체계에 대한 인증이 완료되어야 한다.
+     */
+    override fun grantMentorRole(workerId: Long): String {
+        
+        return "a"
+    }
 }

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
@@ -8,6 +8,10 @@ import site.hirecruit.hr.domain.mentor.verify.service.MentorVerificationService
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository
 
+/**
+ * @author 전지환
+ * @since 1.2.0
+ */
 @Service
 class MentorServiceImpl(
     private val workerRepository: WorkerRepository,

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
@@ -35,6 +35,10 @@ class MentorServiceImpl(
     /**
      * HR의 적합한 mentor 승격 절차를 밟아 역할을 worker -> mentor 업데이트한다.
      * 연락체계에 대한 인증이 완료되어야 한다.
+     *
+     * @param workerId
+     * @param verificationCode 사용자가 입력한 인증번호
+     * @return workerId - mentor로 승격된 workerId
      */
     @Transactional
     override fun grantMentorRole(workerId: Long, verificationCode: String): Long {

--- a/src/main/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImpl.kt
@@ -12,6 +12,12 @@ import site.hirecruit.hr.global.util.randomNumberGenerator
 
 private val log = KotlinLogging.logger {}
 
+/**
+ * HR 멘토 인증에 대한 서비스
+ *
+ * @author 전지환
+ * @since 1.2.0
+ */
 @Service
 class MentorVerificationServiceImpl(
     private val verificationEmailSenderService: VerificationEmailSenderService,

--- a/src/main/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImpl.kt
@@ -8,7 +8,6 @@ import site.hirecruit.hr.domain.mailer.verifyEmail.service.VerificationEmailSend
 import site.hirecruit.hr.domain.mentor.verify.entity.MentorEmailVerificationCodeEntity
 import site.hirecruit.hr.domain.mentor.verify.repository.MentorEmailVerificationCodeRepository
 import site.hirecruit.hr.global.util.randomNumberGenerator
-import java.util.*
 
 
 private val log = KotlinLogging.logger {}

--- a/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
@@ -1,0 +1,77 @@
+package site.hirecruit.hr.domain.mentor.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.company.repository.CompanyRepository
+import site.hirecruit.hr.domain.mentor.verify.repository.MentorEmailVerificationCodeRepository
+import site.hirecruit.hr.domain.mentor.verify.service.MentorVerificationService
+import site.hirecruit.hr.domain.test_util.LocalTest
+import site.hirecruit.hr.domain.worker.repository.WorkerRepository
+
+@LocalTest
+@SpringBootTest
+@Transactional
+internal class MentorServiceImplTest{
+
+    @BeforeEach
+    internal fun setUp(
+        @Autowired userRepository: UserRepository,
+        @Autowired workerRepository: WorkerRepository,
+        @Autowired companyRepository: CompanyRepository
+    ) {
+        // 더미데이터 생성, postConstruct 메소드 자동 실행
+        site.hirecruit.hr.global.dummy.SetDummyData(userRepository, workerRepository, companyRepository)
+
+        // 데미데이터가 잘 생성되었는지 검증
+        val expectedImchang = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr")
+        assertThat(expectedImchang?.user?.name).isEqualTo("임창규")
+    }
+
+    @Test @Disabled
+    @DisplayName("worker 에게 mentor 승격절차를 정상적으로 진행할 수 있다.")
+    fun workerToMentorPromotionSuccessfullyWorking(
+        @Autowired workerRepository: WorkerRepository,
+        @Autowired mentorServiceImpl: MentorService,
+        @Autowired mentorVerificationRepository: MentorEmailVerificationCodeRepository
+    ){
+        // Given :: process 를 진행할 worker 찾기
+        val worker = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr") ?: throw Exception("email에 해당하는 worker 없음")
+
+        // When :: process 진행하기
+        val processing = mentorServiceImpl.mentorPromotionProcess(workerId = worker.workerId!!)
+
+        // Then :: DB 에서 조회한 값과 == process 가 반환한 값
+        val verificationCode = mentorVerificationRepository.findByIdOrNull(id = worker.workerId!!)
+        assertThat(processing[worker.workerId]).isEqualTo(verificationCode?.verificationCode)
+    }
+
+    @Test
+    @DisplayName("worker가 입력한 인증번호를 원본과 대조하여 역할을 mentor로 업데이트 한다.")
+    fun updateWorkerToMentorIfAllStepsPassed(
+        @Autowired workerRepository: WorkerRepository,
+        @Autowired mentorVerificationServiceImpl: MentorVerificationService,
+        @Autowired mentorServiceImpl: MentorService
+    ){
+        // Given
+        val worker = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr") ?: throw Exception("email에 해당하는 worker 없음")
+        val sentVerificationCode = mentorVerificationServiceImpl.sendVerificationCode(
+            workerId = worker.workerId!!,
+            workerEmail = worker.user.email,
+            workerName = worker.user.name
+        )
+
+        // when
+        val grantMentorRole = mentorServiceImpl.grantMentorRole(
+            workerId = worker.workerId!!,
+            verificationCode = sentVerificationCode[worker.workerId!!]
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용
* worker의 `user.role` 을 mentor 로 승격하는 비즈니스 로직을 개발 함.

## 의사결정 필요
`val role: Role` 로 선언되어 클래스 내부에서 setter(update method)를 생성 할 수 없었고, 외부에서 role을 getter하기 때문에 `private var` 로 선언했을 때 빌드 에러가 발생했어요. 그래서 우선 UserEntity의 Role 필드를 `var` 로 접근제어를 `public Role role` 로 풀어둔 상태입니다. 

Q: roleUpdate 비즈니스 요구사항에 대해 어떻게 처리하는게 좋을까요 ?

## 이후에 할 일
- [ ] mentor로 등록 엔드포인트 개발


complete task
#203 task 1