### PR TITLE
애플리케이션 profile별로 oauth2 app 나눔

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,7 +16,7 @@ server:
 
 spring:
   config:
-    import: classpath:oauth/github-oauth-test.yml
+    import: classpath:oauth/github-oauth-local.yml
 
   # oauth2 redirect-uri
   security:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -18,7 +18,7 @@ server:
 
 spring:
   config:
-    import: classpath:oauth/github-oauth-test.yml
+    import: classpath:oauth/github-oauth-staging.yml
 
   mvc:
     path match:


### PR DESCRIPTION
## 개요
prod, staging, local별로 oauth2 app을 나누어 테스트 환경과 운영환경을 나누어 테스트를 원할하게함

### pr merge후 해야 하는 작접
- `resource/oauth/` 하위에 `github-oauth-local.yml` 추가
- `resource/oauth/` 하위에 `github-oauth-test.yml`를  `github-oauth-staging.yml` 로 이름 변경
- 
![CleanShot 2022-06-21 at 08 46 57](https://user-images.githubusercontent.com/62932968/174689774-9dd1e67f-114d-4330-8769-a4ec98f40aed.png)

