### PR TITLE
사용자가 Mentor로 승급시 session 및 security context동기화 및 frontend에 USER_TYPE cookie 반환

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/mentor/aop/MentorServiceAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/aop/MentorServiceAspect.kt
@@ -1,0 +1,58 @@
+package site.hirecruit.hr.domain.mentor.aop
+
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.springframework.stereotype.Component
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.service.SecurityContextAccessService
+import site.hirecruit.hr.global.data.SessionAttribute
+import javax.servlet.http.HttpSession
+
+/**
+ * MentorService에 대한 Aspect class
+ *
+ * @author 정시원
+ * @since 1.2
+ */
+@Component
+@Aspect
+class MentorServiceAspect(
+    private val httpSession: HttpSession,
+    private val securityContextAccessService: SecurityContextAccessService
+) {
+
+    @Pointcut("execution(* site.hirecruit.hr.domain.mentor.service.MentorService+.grantMentorRole(..))")
+    fun mentorService_grantMentorRolePointcut(){}
+
+    /**
+     * Mentor의 AuthUserInfo를 세션에 등록하고, Role를 Spring Security에 동기화한다.
+     *
+     * @see site.hirecruit.hr.domain.mentor.service.MentorService.grantMentorRole
+     */
+    @AfterReturning("mentorService_grantMentorRolePointcut()")
+    fun updateSessionAndSecurityContextByMentorAuthUserInfo(){
+        val authUserInfoBeforeMentor = httpSession.getAttribute(SessionAttribute.AUTH_USER_INFO.attributeName) as AuthUserInfo
+
+        val authUserInfoAfterMentor = AuthUserInfo(
+            githubId = authUserInfoBeforeMentor.githubId,
+            name = authUserInfoBeforeMentor.name,
+            email = authUserInfoBeforeMentor.email,
+            profileImgUri = authUserInfoBeforeMentor.profileImgUri,
+            role = Role.MENTOR
+        )
+
+        setMentorInfoInSession(authUserInfoAfterMentor)
+        updateUserRoleInSecurityContext(authUserInfoAfterMentor)
+    }
+
+    private fun updateUserRoleInSecurityContext(authUserInfo: AuthUserInfo) {
+        securityContextAccessService.updateAuthentication(authUserInfo)
+    }
+
+    private fun setMentorInfoInSession(mentorAuthUserInfo: AuthUserInfo){
+        httpSession.setAttribute(SessionAttribute.AUTH_USER_INFO.attributeName, mentorAuthUserInfo)
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
@@ -1,18 +1,23 @@
 package site.hirecruit.hr.domain.mentor.controller
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.mentor.dto.MentorDto
 import site.hirecruit.hr.domain.mentor.service.MentorService
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
+import site.hirecruit.hr.global.util.CookieMakerUtil
 import springfox.documentation.annotations.ApiIgnore
+import javax.servlet.http.HttpServletResponse
 
 @RestController
 @RequestMapping("/api/v1/mentor")
 class MentorController(
-    private val mentorServiceImpl: MentorService
+    private val mentorServiceImpl: MentorService,
+    @Value("\${server.servlet.session.cookie.domain}") private val hrDomain: String
 ) {
 
     /**
@@ -48,7 +53,8 @@ class MentorController(
      */
     @PatchMapping("/promotion/process/verify")
     fun verifyVerificationMethod(
-        @RequestBody mentorVerifyVerificationMethodRequestDto: MentorDto.MentorVerifyVerificationMethodRequestDto
+        @RequestBody mentorVerifyVerificationMethodRequestDto: MentorDto.MentorVerifyVerificationMethodRequestDto,
+        response: HttpServletResponse
     ): ResponseEntity<Map<String, String>> {
 
         // 적절한 검증을 통해 mentor로 등업
@@ -56,6 +62,9 @@ class MentorController(
             mentorVerifyVerificationMethodRequestDto.workerId,
             mentorVerifyVerificationMethodRequestDto.verificationCode,
         )
+
+        val userTypeCookie = CookieMakerUtil.userTypeCookie(Role.MENTOR.name, hrDomain)
+        response.addCookie(userTypeCookie)
 
         return ResponseEntity
             .status(HttpStatus.OK)


### PR DESCRIPTION
## 개요
Spring AOP를 사용해 mentor 승급시 session과 security context에 정보를 동기화 하였고,
Frontend에 `USER_TYPE` 쿠키에 사용자 role를 담아 전달하여 사용자를 역할별로 판별할 수 있게 함.