### PR TITLE
hotfix/서버에서 로그인된 worker를 재인증/인가 할 필요 없다.

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
@@ -53,9 +53,7 @@ class MentorController(
     fun verifyVerificationMethod(
         @CurrentAuthUserInfo @ApiIgnore
         authUserInfo: AuthUserInfo,
-
-        @RequestBody verificationCode : String,
-
+        @RequestParam verificationCode : String,
         response: HttpServletResponse
     ): ResponseEntity<Map<String, String>> {
 

--- a/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.domain.mentor.dto.MentorDto
 import site.hirecruit.hr.domain.mentor.service.MentorService
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import site.hirecruit.hr.global.util.CookieMakerUtil
@@ -23,44 +22,47 @@ class MentorController(
     /**
      * role: worker가 mentor가 되기 위해서 거쳐야 하는 인증 API 입니다.
      *
-     * @param workerId 등업대상
-     * @param authUserInfo AOP, 현재 로그인 된 사용자
+     * @param authUserInfo 현재 로그인 된 사용자
      * @return ResponseEntity
      */
-    @PostMapping("/promotion/process/{workerId}")
+    @PostMapping("/promotion/process")
     fun executeMentorPromotion(
-        @PathVariable
-        workerId: Long,
         @CurrentAuthUserInfo @ApiIgnore
         authUserInfo: AuthUserInfo,
     ): ResponseEntity<Map<String, String>> {
 
         // service 실행
-        mentorServiceImpl.mentorPromotionProcess(workerId, authUserInfo)
+        val mentorPromotionProcess =
+            mentorServiceImpl.mentorPromotionProcess(authUserInfo.githubId)
 
         // ok response
         return ResponseEntity
             .status(HttpStatus.OK)
             .body(
-                mapOf("message" to "workerId: $workerId 에게 성공적으로 인증번호를 보냈습니다.")
+                mapOf("message" to "workerId: ${mentorPromotionProcess.keys.first()} 에게 성공적으로 인증번호를 보냈습니다.")
             )
     }
 
     /**
      * 인증 체계에 대한 검증을 요청하는 controller
      *
-     * @param mentorVerifyVerificationMethodRequestDto mentor 로 등업하기 위해 검증 필요한 data들
+     * @param authUserInfo 로그인된 사용자
+     * @param verificationCode 사용자가 입력한 인증번호
      */
     @PatchMapping("/promotion/process/verify")
     fun verifyVerificationMethod(
-        @RequestBody mentorVerifyVerificationMethodRequestDto: MentorDto.MentorVerifyVerificationMethodRequestDto,
+        @CurrentAuthUserInfo @ApiIgnore
+        authUserInfo: AuthUserInfo,
+
+        @RequestBody verificationCode : String,
+
         response: HttpServletResponse
     ): ResponseEntity<Map<String, String>> {
 
         // 적절한 검증을 통해 mentor로 등업
         val mentorId = mentorServiceImpl.grantMentorRole(
-            mentorVerifyVerificationMethodRequestDto.workerId,
-            mentorVerifyVerificationMethodRequestDto.verificationCode,
+            githubId = authUserInfo.githubId,
+            verificationCode = verificationCode
         )
 
         val userTypeCookie = CookieMakerUtil.userTypeCookie(Role.MENTOR.name, hrDomain)

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorService.kt
@@ -1,8 +1,6 @@
 package site.hirecruit.hr.domain.mentor.service
 
-import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-
 interface MentorService {
-    fun mentorPromotionProcess(workerId: Long, authUserInfo: AuthUserInfo) : Map<Long, String>
-    fun grantMentorRole(workerId: Long, verificationCode: String) : Long
+    fun mentorPromotionProcess(githubId: Long) : Map<Long, String>
+    fun grantMentorRole(githubId: Long, verificationCode: String) : Long
 }

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
@@ -1,9 +1,7 @@
 package site.hirecruit.hr.domain.mentor.service
 
-import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.mentor.verify.service.MentorVerificationService
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
@@ -23,14 +21,12 @@ class MentorServiceImpl(
      * worker -> mentor 로의 승격절차를 밟는다.
      * 연락수단에 대해 인증을 요청한다.
      *
-     * @param workerId mentor로 승격하고 싶은 workerId
+     * @param githubId mentor로 승격하고 싶은 workerId
      * @return workerId : verificationCode
      */
-    override fun mentorPromotionProcess(workerId: Long, authUserInfo: AuthUserInfo): Map<Long, String> {
-        // 현재 worker가 맞는지 verify
-        val workerEntity = findWorkerEntityByWorkerIdOrElseThrow(workerId)
-        if (workerEntity.user.githubId != authUserInfo.githubId)
-            throw IllegalArgumentException("mentorPromotion을 진행할 workerId: $workerId 에 대한 권한이 없음")
+    override fun mentorPromotionProcess(githubId: Long): Map<Long, String> {
+        // githubId로 worker 조회하기
+        val workerEntity = findWorkerEntityByGithubIdOrElseThrow(githubId)
 
         // worker 인증체계에 verificationCode 전송
         val sentVerificationCode = mentorVerificationServiceImpl.sendVerificationCode(
@@ -46,31 +42,31 @@ class MentorServiceImpl(
      * HR의 적합한 mentor 승격 절차를 밟아 역할을 worker -> mentor 업데이트한다.
      * 연락체계에 대한 인증이 완료되어야 한다.
      *
-     * @param workerId
+     * @param githubId 사용자 githubId
      * @param verificationCode 사용자가 입력한 인증번호
      * @return workerId - mentor로 승격된 workerId
      */
     @Transactional
-    override fun grantMentorRole(workerId: Long, verificationCode: String): Long {
-        // 인증번호 검증
-        mentorVerificationServiceImpl.verifyVerificationCode(workerId, verificationCode)
+    override fun grantMentorRole(githubId: Long, verificationCode: String): Long {
+        // githubId로 worker 조회하기
+        val workerEntity = findWorkerEntityByGithubIdOrElseThrow(githubId)
 
-        // user role update:: worker -> mentor
-        val workerEntity = findWorkerEntityByWorkerIdOrElseThrow(workerId)
+        // 인증번호 검증
+        mentorVerificationServiceImpl.verifyVerificationCode(workerEntity.workerId!!, verificationCode)
         workerEntity.user.updateRole(Role.MENTOR)
 
         return workerEntity.workerId!!
     }
 
     /**
-     * workerId를 통해 workerEntity를 찾습니다.
+     * githubId를 통해 workerEntity를 조회합니다.
      *
-     * @param workerId 찾고자 하는 workerId
+     * @param githubId 찾고자 하는 사용자 githubId
      * @throws Exception worker가 존재하지 않을 때.
      * @return WorkerEntity
      */
-    private fun findWorkerEntityByWorkerIdOrElseThrow(workerId: Long): WorkerEntity {
-        return (workerRepository.findByIdOrNull(workerId)
-            ?: throw IllegalArgumentException("workerId: $workerId 에 해당하는 worker를 찾을 수 없음"))
+    private fun findWorkerEntityByGithubIdOrElseThrow(githubId: Long): WorkerEntity {
+        return (workerRepository.findByUser_GithubId(githubId)
+            ?: throw IllegalArgumentException("workerId: $githubId 에 해당하는 worker를 찾을 수 없음"))
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
@@ -21,7 +21,7 @@ class MentorServiceImpl(
      * worker -> mentor 로의 승격절차를 밟는다.
      * 연락수단에 대해 인증을 요청한다.
      *
-     * @param githubId mentor로 승격하고 싶은 workerId
+     * @param githubId mentor로 승격하고 싶은 githubId
      * @return workerId : verificationCode
      */
     override fun mentorPromotionProcess(githubId: Long): Map<Long, String> {

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerRepository.kt
@@ -9,5 +9,4 @@ import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 interface WorkerRepository : JpaRepository<WorkerEntity, Long>, WorkerCustomRepository {
 
     fun findByUser_GithubId(githubId: Long): WorkerEntity?
-    fun findByUser_Email(userEmail: String): WorkerEntity?
 }

--- a/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
@@ -20,6 +20,8 @@ import site.hirecruit.hr.domain.worker.repository.WorkerRepository
 @Transactional
 internal class MentorServiceImplTest{
 
+    private val GITHUB_ID = 67095821L
+
     @BeforeEach
     internal fun setUp(
         @Autowired userRepository: UserRepository,
@@ -30,8 +32,8 @@ internal class MentorServiceImplTest{
         site.hirecruit.hr.global.dummy.SetDummyData(userRepository, workerRepository, companyRepository)
 
         // 데미데이터가 잘 생성되었는지 검증
-        val expectedImchang = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr")
-        assertThat(expectedImchang?.user?.name).isEqualTo("임창규")
+        val expectedImchang = workerRepository.findByUser_GithubId(GITHUB_ID)
+        assertThat(expectedImchang?.user?.name).isEqualTo("전지환")
     }
 
     @Test @Disabled
@@ -42,7 +44,7 @@ internal class MentorServiceImplTest{
         @Autowired mentorVerificationRepository: MentorEmailVerificationCodeRepository
     ){
         // Given :: process 를 진행할 worker 찾기
-        val worker = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr") ?: throw Exception("email에 해당하는 worker 없음")
+        val worker = workerRepository.findByUser_GithubId(GITHUB_ID) ?: throw Exception("email에 해당하는 worker 없음")
 
         // Given :: 로그인
         val authUserInfoCopyWorker = AuthUserInfo(
@@ -55,39 +57,12 @@ internal class MentorServiceImplTest{
 
         // When :: process 진행하기
         val processing = mentorServiceImpl.mentorPromotionProcess(
-            workerId = worker.workerId!!,
-            authUserInfo = authUserInfoCopyWorker
+            githubId = worker.user.githubId,
         )
 
         // Then :: DB 에서 조회한 값과 == process 가 반환한 값
         val verificationCode = mentorVerificationRepository.findByIdOrNull(id = worker.workerId!!)
         assertThat(processing[worker.workerId]).isEqualTo(verificationCode?.verificationCode)
-    }
-
-    @Test @Disabled
-    fun `등업_시킬_worker와_login된_주체는_같아야_한다_다르면_실패한다`(
-        @Autowired workerRepository: WorkerRepository,
-        @Autowired mentorServiceImpl: MentorService,
-    ){
-        // Given :: process 를 진행할 worker 찾기
-        val worker = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr") ?: throw Exception("email에 해당하는 worker 없음")
-
-        // Given :: 로그인
-        val authUserInfoCopyWorker = AuthUserInfo(
-            123L,
-            worker.user.name,
-            worker.user.email,
-            worker.user.profileImgUri,
-            worker.user.role
-        )
-
-        assertThrows<IllegalArgumentException> {
-            // When :: process 진행하기
-            mentorServiceImpl.mentorPromotionProcess(
-                workerId = worker.workerId!!,
-                authUserInfo = authUserInfoCopyWorker
-            )
-        }
     }
 
     @Test @Disabled
@@ -98,7 +73,8 @@ internal class MentorServiceImplTest{
         @Autowired mentorServiceImpl: MentorService
     ){
         // Given :: setup sandbox access worker
-        val worker = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr") ?: throw Exception("email에 해당하는 worker 없음")
+        val worker = workerRepository.findByUser_GithubId(GITHUB_ID) ?: throw Exception("email에 해당하는 worker 없음")
+
         // Given :: send VerificationCode to worker
         val sentVerificationCode = mentorVerificationServiceImpl.sendVerificationCode(
             workerId = worker.workerId!!,
@@ -109,7 +85,7 @@ internal class MentorServiceImplTest{
         // when :: grant 요청 올바른 인증번호로
         assertDoesNotThrow {
             mentorServiceImpl.grantMentorRole(
-                workerId = worker.workerId!!,
+                githubId = GITHUB_ID,
                 verificationCode = sentVerificationCode
             )
         }

--- a/src/test/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImplTest.kt
@@ -17,6 +17,8 @@ import site.hirecruit.hr.global.util.randomNumberGenerator
 @Transactional
 internal class MentorVerificationServiceImplTest{
 
+    private val GITHUB_ID = 67095821L
+
     @BeforeEach
     internal fun setUp(
         @Autowired userRepository: UserRepository,
@@ -27,8 +29,8 @@ internal class MentorVerificationServiceImplTest{
         site.hirecruit.hr.global.dummy.SetDummyData(userRepository, workerRepository, companyRepository)
 
         // 데미데이터가 잘 생성되었는지 검증
-        val expectedImchang = workerRepository.findByUser_Email("hirecruit@gsm.hs.kr")
-        assertThat(expectedImchang?.user?.name).isEqualTo("임창규")
+        val expectedImchang = workerRepository.findByUser_GithubId(GITHUB_ID)
+        assertThat(expectedImchang?.user?.name).isEqualTo("전지환")
     }
 
     @Test
@@ -70,7 +72,7 @@ internal class MentorVerificationServiceImplTest{
 
 
     private fun `SES에서 승인된 이메일을 갖고 있는 worker 가져오기 `(workerRepository: WorkerRepository): WorkerEntity {
-        return workerRepository.findByUser_Email("hirecruit@gsm.hs.kr")
+        return workerRepository.findByUser_GithubId(GITHUB_ID)
             ?: throw Exception("email 보낼 대상이 없기 때문에 비즈니스 로직 수행 불가")
     }
 }


### PR DESCRIPTION
## 작업 내용
* `멘토 승급 요청 API`에 대해 `workerId`를 FE에게 추가적으로 받을 필요가 없다.
* `멘토 승급 검증 API`에 대해 `workerId`를 FE에게 추가적으로 받을 필요가 없다.

API 문서 참고하세요. 
