### PR TITLE
직장인 조회 로직 멘토, 직장인 구분

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.querydsl.core.annotations.QueryProjection
 import org.hibernate.validator.constraints.Length
 import org.hibernate.validator.constraints.URL
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.validator.annoation.CompanyIsNotExistByCompanyId
 import javax.validation.constraints.Max
@@ -57,6 +58,8 @@ class WorkerDto {
         val devYear: Int?,
 
         val position: String?,
+
+        val userType: Role,
 
         @field:JsonProperty("company")
         val companyInfoDto: CompanyDto.Info

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerCustomRepositoryImpl.kt
@@ -3,6 +3,7 @@ package site.hirecruit.hr.domain.worker.repository
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import site.hirecruit.hr.domain.auth.entity.QUserEntity.userEntity
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.company.dto.QCompanyDto_Info
 import site.hirecruit.hr.domain.company.entity.QCompanyEntity.companyEntity
 import site.hirecruit.hr.domain.worker.dto.QWorkerDto_Info
@@ -30,6 +31,7 @@ class WorkerCustomRepositoryImpl(
                 workerEntity.giveLink,
                 workerEntity.devYear,
                 workerEntity.position,
+                workerEntity.user.role,
                 QCompanyDto_Info(
                         workerEntity.company.companyId,
                         workerEntity.company.name,
@@ -56,6 +58,7 @@ class WorkerCustomRepositoryImpl(
                     workerEntity.giveLink,
                     workerEntity.devYear,
                     workerEntity.position,
+                    workerEntity.user.role,
                     QCompanyDto_Info(
                         Expressions.constantAs(companyId, workerEntity.company.companyId),
                         workerEntity.company.name,
@@ -83,6 +86,7 @@ class WorkerCustomRepositoryImpl(
                     workerEntity.giveLink,
                     workerEntity.devYear,
                     workerEntity.position,
+                    workerEntity.user.role,
                     QCompanyDto_Info(
                         workerEntity.company.companyId,
                         workerEntity.company.name,

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
@@ -34,6 +35,7 @@ class AuthUserWorkerServiceImpl(
             giveLink = workerEntity.giveLink,
             devYear =  workerEntity.devYear,
             position = workerEntity.position,
+            userType = authUserInfo.role,
             companyInfoDto = CompanyDto.Info(
                 companyId = workerEntity.company.companyId!!,
                 name = workerEntity.company.name,

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
@@ -58,6 +59,7 @@ class WorkerRegistrationServiceImpl(
             giveLink = savedWorkerEntity.giveLink,
             devYear = savedWorkerEntity.devYear,
             position = savedWorkerEntity.position,
+            userType = Role.WORKER,
             companyInfoDto = CompanyDto.Info(
                 companyId = companyEntity.companyId!!,
                 name = companyEntity.name,

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerLockupServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerLockupServiceImplTest.kt
@@ -6,6 +6,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
@@ -34,6 +35,7 @@ internal class WorkerLockupServiceImplTest {
             giveLink = workerEntity.giveLink,
             devYear = workerEntity.devYear,
             position = workerEntity.position,
+            userType = Role.WORKER,
             companyInfoDto = CompanyDto.Info(
                 companyId = workerEntity.company.companyId!!,
                 name = workerEntity.company.name,


### PR DESCRIPTION
## 개요
직장인 전체조회에 멘토, 직장인을 구분하기 위해 userType필드를 추가하여 해당 사용자의 role를 반환하여 구분할 수 있게 함

모든 직장인 조회 로직에 적용되었습니다. API문서를 확인해주세요