### PR TITLE
기본 정보 수정시 session 데이터 동기화 

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspect.kt
@@ -29,6 +29,9 @@ class UserSessionInfoUpdateAspect (
     @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService+.rollback(..))")
     private fun userRegistrationRollbackService_rollback(){}
 
+    @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserUpdateService+.update(..))")
+    private fun userUpdateService_update(){}
+
     /**
      * [site.hirecruit.hr.domain.auth.service.UserAuthService.authentication]에서의 유저 인증 수행 후 세션을 발급하는 AOP method
      */

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserUpdateService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserUpdateService.kt
@@ -5,8 +5,15 @@ import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
 
 /**
  * User의 기본정보를 Update하는 Service
+ * @author 정시ㅜ언
+ * @since 1.2
  */
 interface UserUpdateService {
 
-    fun update(updateDto: UserUpdateDto, authUserInfo: AuthUserInfo)
+    /**
+     * 사용자의 기본 정보를 수정한다.
+     *
+     * @return 수정된 사용자 정보 DTO
+     */
+    fun update(updateDto: UserUpdateDto, authUserInfo: AuthUserInfo): AuthUserInfo
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserUpdateService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserUpdateService.kt
@@ -5,7 +5,7 @@ import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
 
 /**
  * User의 기본정보를 Update하는 Service
- * @author 정시ㅜ언
+ * @author 정시원
  * @since 1.2
  */
 interface UserUpdateService {

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
@@ -11,7 +11,7 @@ class UserUpdateServiceImpl(
     private val userRepository: UserRepository
 ): UserUpdateService {
 
-    override fun update(updateDto: UserUpdateDto, authUserInfo: AuthUserInfo) {
+    override fun update(updateDto: UserUpdateDto, authUserInfo: AuthUserInfo): AuthUserInfo {
         val userEntity = userRepository.findByGithubId(authUserInfo.githubId)
             ?: throw IllegalArgumentException("Cannot found user info")
 
@@ -22,7 +22,15 @@ class UserUpdateServiceImpl(
             }
         }
 
-        userRepository.save(userEntity)
+        val savedUserEntity = userRepository.save(userEntity)
+        return AuthUserInfo(
+            githubId = savedUserEntity.githubId,
+            githubLoginId = savedUserEntity.githubLoginId,
+            name = savedUserEntity.name,
+            email = savedUserEntity.email,
+            profileImgUri = savedUserEntity.profileImgUri,
+            role = savedUserEntity.role
+        )
     }
 
 


### PR DESCRIPTION
## 개요 
기본 정보 수정시 session에 있는 정보들을 동기화 해야 한다.  동기화 하기 위해 `UserUpdateService.update`매서드는 업데이트 된 사용자 기본 정보를 `AuthUserInfo`객체로 반환한 후 해당 객체를 AOP를 이용하여 session에 정보를 동기화 하였다.

## Reference
#216 