### PR TITLE
사용자 기본 정보 수정 API Mentor가 email를 수정하면 WORKER로 강등

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/controller/UserController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/controller/UserController.kt
@@ -1,23 +1,30 @@
 package site.hirecruit.hr.domain.auth.controller
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
 import site.hirecruit.hr.domain.auth.service.UserUpdateService
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
+import site.hirecruit.hr.global.util.CookieMakerUtil
 import springfox.documentation.annotations.ApiIgnore
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 
 @RestController
 @RequestMapping("/api/v1/user")
 class UserController(
-    private val userUpdateService: UserUpdateService
+    private val userUpdateService: UserUpdateService,
+
+    @Value("\${hr.domain}")
+    private val hrDomain: String
 ) {
 
     @PatchMapping("/me")
@@ -27,10 +34,15 @@ class UserController(
         authUserInfo: AuthUserInfo,
 
         @RequestBody @Valid
-        updateDto: UserUpdateDto
-    ): ResponseEntity<Unit>{
-        userUpdateService.update(updateDto, authUserInfo)
+        updateDto: UserUpdateDto,
 
+        request: HttpServletRequest,
+        response: HttpServletResponse
+    ): ResponseEntity<Unit>{
+        val updatedAuthUserInfo = userUpdateService.update(updateDto, authUserInfo)
+
+        val userTypeCookie = CookieMakerUtil.userTypeCookie(updatedAuthUserInfo.role.name, hrDomain)
+        response.addCookie(userTypeCookie)
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
             .build()
     }

--- a/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/entity/UserEntity.kt
@@ -1,5 +1,6 @@
 package site.hirecruit.hr.domain.auth.entity
 
+import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
 import javax.persistence.*
 
 /**
@@ -34,6 +35,11 @@ class UserEntity(
 
     fun updateRole(role: Role){
         this.role = role
+    }
+
+    fun update(updateDto: UserUpdateDto) = apply {
+        this.email = updateDto.email!!
+        this.name = updateDto.name!!
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
@@ -1,8 +1,11 @@
 package site.hirecruit.hr.domain.auth.service.impl
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
+import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.auth.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserUpdateService
 
@@ -11,8 +14,9 @@ class UserUpdateServiceImpl(
     private val userRepository: UserRepository
 ): UserUpdateService {
 
-    override fun update(updateDto: UserUpdateDto, authUserInfo: AuthUserInfo): AuthUserInfo {
-        val userEntity = userRepository.findByGithubId(authUserInfo.githubId)
+    @Transactional
+    override fun update(updateDto: UserUpdateDto, authUserInfoBeforeUpdate: AuthUserInfo): AuthUserInfo {
+        val userEntity = userRepository.findByGithubId(authUserInfoBeforeUpdate.githubId)
             ?: throw IllegalArgumentException("Cannot found user info")
 
         updateDto.updateColumns.forEach {
@@ -23,6 +27,9 @@ class UserUpdateServiceImpl(
         }
 
         val updatedUserEntity = userRepository.save(userEntity)
+
+        if(isMentorEmailChanged(authUserInfoBeforeUpdate, updatedUserEntity))
+            updatedUserEntity.role = Role.WORKER
         return AuthUserInfo(
             githubId = updatedUserEntity.githubId,
             githubLoginId = updatedUserEntity.githubLoginId,
@@ -31,6 +38,13 @@ class UserUpdateServiceImpl(
             profileImgUri = updatedUserEntity.profileImgUri,
             role = updatedUserEntity.role
         )
+    }
+
+    private fun isMentorEmailChanged(authUserInfoBeforeUpdate: AuthUserInfo, updatedUserEntity: UserEntity): Boolean {
+        if(authUserInfoBeforeUpdate.role != Role.MENTOR) // 멘토가 아니라면
+            return false
+
+        return authUserInfoBeforeUpdate.email.equals(updatedUserEntity.email).not()
     }
 
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
@@ -19,17 +19,10 @@ class UserUpdateServiceImpl(
         val userEntity = userRepository.findByGithubId(authUserInfoBeforeUpdate.githubId)
             ?: throw IllegalArgumentException("Cannot found user info")
 
-        updateDto.updateColumns.forEach {
-            when(it) {
-                UserUpdateDto.Column.EMAIL      -> userEntity.email = updateDto.email!!
-                UserUpdateDto.Column.NAME       -> userEntity.name = updateDto.name!!
-            }
-        }
-
-        val updatedUserEntity = userRepository.save(userEntity)
+        val updatedUserEntity = userEntity.update(updateDto)
 
         if(isMentorEmailChanged(authUserInfoBeforeUpdate, updatedUserEntity))
-            updatedUserEntity.role = Role.WORKER
+            updatedUserEntity.updateRole(Role.WORKER)
         return AuthUserInfo(
             githubId = updatedUserEntity.githubId,
             githubLoginId = updatedUserEntity.githubLoginId,

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
@@ -22,14 +22,14 @@ class UserUpdateServiceImpl(
             }
         }
 
-        val savedUserEntity = userRepository.save(userEntity)
+        val updatedUserEntity = userRepository.save(userEntity)
         return AuthUserInfo(
-            githubId = savedUserEntity.githubId,
-            githubLoginId = savedUserEntity.githubLoginId,
-            name = savedUserEntity.name,
-            email = savedUserEntity.email,
-            profileImgUri = savedUserEntity.profileImgUri,
-            role = savedUserEntity.role
+            githubId = updatedUserEntity.githubId,
+            githubLoginId = updatedUserEntity.githubLoginId,
+            name = updatedUserEntity.name,
+            email = updatedUserEntity.email,
+            profileImgUri = updatedUserEntity.profileImgUri,
+            role = updatedUserEntity.role
         )
     }
 


### PR DESCRIPTION
## 개요
mentor가 email를 변경하면 ROLE를 WORKER로 강등하도록 로직을 작성했습니다.
사용자 기본 정보 수정 API 호출시 앞으로 USER_TYPE 쿠키를 client에 보냅니다.

+추가적으로 해당 로직의 refactoring을 진행했습니다.

## 앞으로 할 일
사용자 기본 정보 수정, 프로필 수정 API에 `updateColumns`를 통해 특정 컬럼만 update할 수 있도록 구분을 하는 로직이 있었지만 불필요 하여 JPA변경감지로 update하도록 로직을 변경할 예정입니다.