### PR TITLE
Oauth2 예외 authorization_request_not_found  핸들링

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
@@ -52,6 +52,7 @@ class SecurityExceptionHandler(
     ) {
         val redirectUrlBuilder = UriComponentsBuilder.fromUriString(redirectBaseUri)
         log.debug { "Oauth2AuthenticationExceptionHandler Active" }
+
         when(ex.error.errorCode){
             OAuth2ErrorCodes.ACCESS_DENIED -> { // 유저가 Oauth2 login동의를 하지 않을 때
                 log.info { "OAuth2ErrorCodes.${OAuth2ErrorCodes.ACCESS_DENIED}"}
@@ -70,7 +71,8 @@ class SecurityExceptionHandler(
                         error_code = '${ex.error.errorCode}',
                         error_description = '${ex.error.description}'
                     }
-                """.trimIndent() } //
+                """.trimIndent() }
+
                 redirectUrlBuilder.queryParam("login", "fail")
                 redirectUrlBuilder.queryParam("server_error", true)
             }

--- a/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
@@ -58,7 +58,10 @@ class SecurityExceptionHandler(
                 redirectUrlBuilder.queryParam("login", "cancel")
             }
             else -> {
-                log.error(ex){ "예외 처리하지 않은 OAuth2 Exception 발생" } //
+                log.error(ex){ """
+                    예외 처리하지 않은 OAuth2 Exception 발생
+                    error details='${ex.error}'
+                """.trimIndent() } //
                 redirectUrlBuilder.queryParam("login", "fail")
                 redirectUrlBuilder.queryParam("server_error", true)
             }

--- a/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/SecurityExceptionHandler.kt
@@ -57,10 +57,19 @@ class SecurityExceptionHandler(
                 log.info { "OAuth2ErrorCodes.${OAuth2ErrorCodes.ACCESS_DENIED}"}
                 redirectUrlBuilder.queryParam("login", "cancel")
             }
-            else -> {
+            "authorization_request_not_found" -> {
+                log.info { """
+                    authorization_request_not_found 발생 
+                """.trimIndent() }
+                redirectUrlBuilder.queryParam("login", "fail")
+                redirectUrlBuilder.queryParam("server_error", false)
+            }else -> {
                 log.error(ex){ """
                     예외 처리하지 않은 OAuth2 Exception 발생
-                    error details='${ex.error}'
+                    error details={
+                        error_code = '${ex.error.errorCode}',
+                        error_description = '${ex.error.description}'
+                    }
                 """.trimIndent() } //
                 redirectUrlBuilder.queryParam("login", "fail")
                 redirectUrlBuilder.queryParam("server_error", true)


### PR DESCRIPTION
# 개요
사용자의 github login 인증 정보가 잘못된 경우 `authorization_request_not_found` error가 발생합니다. 
그래서 error발생에 관련된 로깅 및 리다이렉션을 수행하는 예외 핸들링 로직을 작성했습니다.

`authorization_request_not_found`에러는 github oauth인증서버 오류이므로 server에러가 아닙니다.


## 관련 스크린샷
### 예외 처리전 logging
![CleanShot 2022-06-30 at 11 35 28](https://user-images.githubusercontent.com/62932968/176580622-58774b78-cfec-4d96-8799-d3262bc64189.png)

### 예외 처리 후 logging
```
2022-06-30 11:47:04.411  INFO 55725 --- [nio-8080-exec-1] s.h.h.g.s.h.SecurityExceptionHandler     : authorization_request_not_found 발생 
```

## API 변경사항
@sunwoo0706 @songsihyeon

`[GET] /api/v1/auth/oauth2/authorization/github - GitHub OAuth 로그인` api의 일부가 수정되었습니다.
#### 전
![CleanShot 2022-06-30 at 11 42 14](https://user-images.githubusercontent.com/62932968/176582212-14c3f226-2a2a-4481-a730-52bec618bc71.png)

#### 후
![CleanShot 2022-06-30 at 11 42 58](https://user-images.githubusercontent.com/62932968/176582326-6fdafe33-37e0-403c-a6ec-b4d66151bdb7.png)