### PR TITLE
Fix cors

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -127,13 +127,15 @@ class SecurityConfig(
     @Profile(ServerProfile.DEFAULT, ServerProfile.LOCAL, ServerProfile.STAGING)
     inner class TestingRole: WebSecurityConfigurerAdapter(){
         override fun configure(http: HttpSecurity) {
-            cors(http)
+            http.headers { headers ->
+                headers.frameOptions {
+                    it.sameOrigin()
+                }
+            }
 
             http
                 .csrf().disable()
-                .headers().frameOptions().disable()
-                .and()
-                .cors().disable()
+
             http
                 .authorizeRequests()
                 .antMatchers(
@@ -149,6 +151,7 @@ class SecurityConfig(
             logoutConfig(http)
             accessDenied(http)
             oauth2Login(http)
+            cors(http)
         }
     }
 }


### PR DESCRIPTION
## 개요
CORS 해결했습니다. 스테이징 서버 h2-console cors는 믿음으로 갑니다.

## 문제 원인
#212  
security cors설정은 disable해버리면 WebMVC cors설정을 security에서 적용을하지 않습니다.