### PR TITLE
Fix h2-console cors 해결

### DIFF
--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -4,8 +4,8 @@ import mu.KotlinLogging
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.builders.WebSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
@@ -13,7 +13,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User
 import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
-import org.springframework.security.web.authentication.HttpStatusEntryPoint
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
 import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.global.data.ServerProfile
@@ -126,6 +125,16 @@ class SecurityConfig(
     @Configuration
     @Profile(ServerProfile.DEFAULT, ServerProfile.LOCAL, ServerProfile.STAGING)
     inner class TestingRole: WebSecurityConfigurerAdapter(){
+
+        override fun configure(web: WebSecurity) {
+            web
+                /**
+                 * antMatchers에 설정한 url에 대해 security 설정을 무시하는 설정
+                 */
+                .ignoring()
+                .antMatchers("/h2-console/**")
+        }
+
         override fun configure(http: HttpSecurity) {
             http.headers { headers ->
                 headers.frameOptions {


### PR DESCRIPTION
## 개요
#226  에서 해결하지 못한 h2-console에 Invalid CORS request를 해결했습니다. 

## 해결 방법
antMatcher표현식 기준으로  `/h2-console/**` 형식의 url로 오는 요청에 대해 spring security가 관여하지 않도록 했습니다.