### PR TITLE
Fix validator annotation 잘못 수정

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/company/validator/annoation/CompanyIsNotExistByCompanyId.kt
+++ b/src/main/java/site/hirecruit/hr/domain/company/validator/annoation/CompanyIsNotExistByCompanyId.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KClass
  */
 @MustBeDocumented
 @Constraint(validatedBy = [CompanyExistValidator::class])
-@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.CLASS)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class CompanyIsNotExistByCompanyId(
     val message: String = "해당 Company를 찾을 수 없습니다",

--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -67,7 +67,6 @@ class WorkerDto {
         val companyInfoDto: CompanyDto.Info
     )
 
-    @CompanyIsNotExistByCompanyId
     data class Update(
         @field:JsonProperty("companyId") @get:JsonGetter("companyId")
         @field:NotNull @field:Min(1) @field:CompanyIsNotExistByCompanyId


### PR DESCRIPTION
## 개요
`CompanyIsNotExistByCompanyId` annotation은 Long타입의 필드에만 사용할 수 있지만 #223 에서 실수로 annotation을 변경하여 
![CleanShot 2022-07-01 at 12 23 28](https://user-images.githubusercontent.com/62932968/176817277-be9a4545-d6f6-4d2d-914b-64b9893d7d5d.png)

스크린샷에 나와있는 에러가 발생하였습니다.