### PR TITLE
auth도메인에서 user도메인 분리 (아직 모두 완료되지 않음)

### DIFF
--- a/src/main/java/site/hirecruit/hr/batch/github_login_id/job/AddGithubLoginIdJobConfiguration.kt
+++ b/src/main/java/site/hirecruit/hr/batch/github_login_id/job/AddGithubLoginIdJobConfiguration.kt
@@ -16,7 +16,7 @@ import org.springframework.data.domain.Sort
 import site.hirecruit.hr.batch.github_login_id.service.LockupGithubLoginIdService
 import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 
 
 private val log = KotlinLogging.logger {  }

--- a/src/main/java/site/hirecruit/hr/batch/github_login_id/job/AddGithubLoginIdJobConfiguration.kt
+++ b/src/main/java/site/hirecruit/hr/batch/github_login_id/job/AddGithubLoginIdJobConfiguration.kt
@@ -12,10 +12,9 @@ import org.springframework.batch.item.data.RepositoryItemWriter
 import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder
 import org.springframework.batch.item.data.builder.RepositoryItemWriterBuilder
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Configuration
 import org.springframework.data.domain.Sort
 import site.hirecruit.hr.batch.github_login_id.service.LockupGithubLoginIdService
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspect.kt
@@ -36,7 +36,7 @@ class UserSessionInfoUpdateAspect (
      * [site.hirecruit.hr.domain.auth.service.UserAuthService.authentication]에서의 유저 인증 수행 후 세션을 발급하는 AOP method
      */
     @AfterReturning(
-        "userAuthService_AuthenticationMethodPointCut() || userRegistrationRollbackService_rollback()",
+        "userAuthService_AuthenticationMethodPointCut() || userRegistrationRollbackService_rollback() || userUpdateService_update()",
         returning = "authUserInfo"
     )
     private fun setSessionByAuthUserInfo(authUserInfo: AuthUserInfo): Any{

--- a/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import site.hirecruit.hr.domain.auth.service.UserRegistrationService
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import site.hirecruit.hr.global.util.CookieUtil
 import springfox.documentation.annotations.ApiIgnore

--- a/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/controller/AuthController.kt
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import site.hirecruit.hr.domain.auth.service.UserRegistrationService
+import site.hirecruit.hr.domain.user.service.UserRegistrationService
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo

--- a/src/main/java/site/hirecruit/hr/domain/auth/controller/UserController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/controller/UserController.kt
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
+import site.hirecruit.hr.domain.user.dto.UserUpdateDto
 import site.hirecruit.hr.domain.auth.service.UserUpdateService
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import site.hirecruit.hr.global.util.CookieUtil

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/AuthUserInfo.kt
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Scope
 import org.springframework.context.annotation.ScopedProxyMode
 import org.springframework.stereotype.Component
 import org.springframework.web.context.WebApplicationContext
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 
 /**
  * 인증/인가 시 유저의 정보를 담고 있는 객체

--- a/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/repository/UserRepository.kt
@@ -1,7 +1,7 @@
 package site.hirecruit.hr.domain.auth.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.UserEntity
 
 interface UserRepository : JpaRepository<UserEntity, Long>, UserCustomRepository {
     fun existsByGithubId(githubId: Long) : Boolean

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserRegistrationService.kt
@@ -1,7 +1,7 @@
 package site.hirecruit.hr.domain.auth.service
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 
 /**
  * 유저생성 서비스

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/UserUpdateService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/UserUpdateService.kt
@@ -1,7 +1,7 @@
 package site.hirecruit.hr.domain.auth.service
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
+import site.hirecruit.hr.domain.user.dto.UserUpdateDto
 
 /**
  * User의 기본정보를 Update하는 Service

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/OAuth2ProcessorFacadeImpl.kt
@@ -3,7 +3,7 @@ package site.hirecruit.hr.domain.auth.service.impl
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.OAuthProcessorFacade
 import site.hirecruit.hr.domain.auth.service.UserAuthService
 import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.user.entity.Role
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
 import site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImpl.kt
@@ -5,7 +5,7 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
 import site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -4,7 +4,7 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceImpl.kt
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
-import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserRegistrationService
 import site.hirecruit.hr.global.event.UserRegistrationEvent

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
@@ -5,7 +5,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserAuthService

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
@@ -7,7 +7,7 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserAuthService
 import site.hirecruit.hr.global.data.SessionAttribute
 import javax.servlet.http.HttpSession

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
@@ -3,7 +3,7 @@ package site.hirecruit.hr.domain.auth.service.impl
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
+import site.hirecruit.hr.domain.user.dto.UserUpdateDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
-import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserUpdateService
 

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserUpdateServiceImpl.kt
@@ -6,7 +6,7 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.dto.UserUpdateDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserUpdateService
 
 @Service

--- a/src/main/java/site/hirecruit/hr/domain/mentor/aop/MentorServiceAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/aop/MentorServiceAspect.kt
@@ -5,7 +5,7 @@ import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Pointcut
 import org.springframework.stereotype.Component
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.service.SecurityContextAccessService
 import site.hirecruit.hr.global.data.SessionAttribute
 import javax.servlet.http.HttpSession

--- a/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/controller/MentorController.kt
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.mentor.service.MentorService
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import site.hirecruit.hr.global.util.CookieUtil

--- a/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImpl.kt
@@ -2,7 +2,7 @@ package site.hirecruit.hr.domain.mentor.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.mentor.verify.service.MentorVerificationService
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity
 import site.hirecruit.hr.domain.worker.repository.WorkerRepository

--- a/src/main/java/site/hirecruit/hr/domain/user/aop/UserRegistrationAspect.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/aop/UserRegistrationAspect.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.aop
+package site.hirecruit.hr.domain.user.aop
 
 import mu.KotlinLogging
 import org.aspectj.lang.annotation.AfterReturning
@@ -28,7 +28,7 @@ class UserRegistrationAspect(
     private val securityContextFacade: SecurityContextAccessService
 ) {
 
-    @Pointcut("execution(* site.hirecruit.hr.domain.auth.service.UserRegistrationService+.registration(..))")
+    @Pointcut("execution(* site.hirecruit.hr.domain.user.service.UserRegistrationService+.registration(..))")
     private fun userRegistrationService_registrationMethodPointCut(){}
 
     /**

--- a/src/main/java/site/hirecruit/hr/domain/user/controller/UserRegistrationController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/controller/UserRegistrationController.kt
@@ -1,22 +1,25 @@
-package site.hirecruit.hr.domain.auth.controller
+package site.hirecruit.hr.domain.user.controller
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
-import site.hirecruit.hr.domain.user.service.UserRegistrationService
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
 import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.user.service.UserRegistrationService
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import site.hirecruit.hr.global.util.CookieUtil
 import springfox.documentation.annotations.ApiIgnore
 import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 
-@Deprecated("해당 controller는 추후 사용되지 않을 예정입니다. domain.user.controller.UserRegistrationController로 해당 controller의 역할이 이전될 예정입니다.")
 @RestController
-@RequestMapping("/api/v1/auth")
-class AuthController(
+@RequestMapping("/api/v1/user")
+class UserRegistrationController(
     private val userRegistrationService: UserRegistrationService,
     @Value("\${hr.domain}") private val hrDomain: String
 ) {
@@ -26,16 +29,15 @@ class AuthController(
         @CurrentAuthUserInfo @ApiIgnore
         authUserInfo: AuthUserInfo,
 
-        @RequestBody  @Valid
+        @RequestBody @Valid
         userRegistrationDto: UserRegistrationDto,
 
         response: HttpServletResponse
-    ): ResponseEntity<AuthUserInfo>{
+    ): ResponseEntity<AuthUserInfo> {
         val registeredAuthUserInfo = userRegistrationService.registration(authUserInfo, userRegistrationDto)
 
         response.addCookie(CookieUtil.userTypeCookie(registeredAuthUserInfo.role.name, hrDomain)) // 등록된 유저의 role을 USER_TYPE 쿠키로 넘겨줌
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(registeredAuthUserInfo)
     }
-
 }

--- a/src/main/java/site/hirecruit/hr/domain/user/dto/UserRegistrationDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/dto/UserRegistrationDto.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.dto
+package site.hirecruit.hr.domain.user.dto
 
 import com.fasterxml.jackson.annotation.JsonGetter
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/src/main/java/site/hirecruit/hr/domain/user/dto/UserUpdateDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/dto/UserUpdateDto.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.dto
+package site.hirecruit.hr.domain.user.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/src/main/java/site/hirecruit/hr/domain/user/entity/Role.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/entity/Role.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.entity
+package site.hirecruit.hr.domain.user.entity
 
 enum class Role(
     val role: String,

--- a/src/main/java/site/hirecruit/hr/domain/user/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/entity/UserEntity.kt
@@ -1,6 +1,6 @@
 package site.hirecruit.hr.domain.user.entity
 
-import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
+import site.hirecruit.hr.domain.user.dto.UserUpdateDto
 import javax.persistence.*
 
 /**
@@ -37,7 +37,7 @@ class UserEntity(
         this.role = role
     }
 
-    fun update(updateDto:UserUpdateDto) = apply {
+    fun update(updateDto: UserUpdateDto) = apply {
         this.email = updateDto.email
         this.name = updateDto.name
     }

--- a/src/main/java/site/hirecruit/hr/domain/user/entity/UserEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/entity/UserEntity.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.entity
+package site.hirecruit.hr.domain.user.entity
 
 import site.hirecruit.hr.domain.auth.dto.UserUpdateDto
 import javax.persistence.*

--- a/src/main/java/site/hirecruit/hr/domain/user/repository/UserCustomRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/repository/UserCustomRepository.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.repository
+package site.hirecruit.hr.domain.user.repository
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 

--- a/src/main/java/site/hirecruit/hr/domain/user/repository/UserCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/repository/UserCustomRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.QAuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.QUserEntity.userEntity
+import site.hirecruit.hr.domain.user.entity.QUserEntity.userEntity
 
 /**
  * UserCustomRepository의 구현체 입니다.

--- a/src/main/java/site/hirecruit/hr/domain/user/repository/UserCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/repository/UserCustomRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.repository
+package site.hirecruit.hr.domain.user.repository
 
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory

--- a/src/main/java/site/hirecruit/hr/domain/user/repository/UserRepository.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/repository/UserRepository.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.repository
+package site.hirecruit.hr.domain.user.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import site.hirecruit.hr.domain.user.entity.UserEntity

--- a/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationService.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.service
+package site.hirecruit.hr.domain.user.service
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.dto.UserRegistrationDto

--- a/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationServiceImpl.kt
@@ -7,7 +7,7 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.global.event.UserRegistrationEvent
 
 /**

--- a/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationServiceImpl.kt
@@ -1,4 +1,4 @@
-package site.hirecruit.hr.domain.auth.service.impl
+package site.hirecruit.hr.domain.user.service
 
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -8,7 +8,6 @@ import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
-import site.hirecruit.hr.domain.auth.service.UserRegistrationService
 import site.hirecruit.hr.global.event.UserRegistrationEvent
 
 /**

--- a/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/dto/WorkerDto.kt
@@ -5,14 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.querydsl.core.annotations.QueryProjection
 import org.hibernate.validator.constraints.Length
 import org.hibernate.validator.constraints.URL
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.validator.annoation.CompanyIsNotExistByCompanyId
 import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotEmpty
 import javax.validation.constraints.NotNull
-import kotlin.math.max
 
 /**
  * Worker 도메인 DTO

--- a/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/entity/WorkerEntity.kt
@@ -2,7 +2,7 @@ package site.hirecruit.hr.domain.worker.entity
 
 import org.hibernate.annotations.OnDelete
 import org.hibernate.annotations.OnDeleteAction
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.company.entity.CompanyEntity
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import javax.persistence.*

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerCustomRepositoryImpl.kt
@@ -3,7 +3,6 @@ package site.hirecruit.hr.domain.worker.repository
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import site.hirecruit.hr.domain.auth.entity.QUserEntity.userEntity
-import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.company.dto.QCompanyDto_Info
 import site.hirecruit.hr.domain.company.entity.QCompanyEntity.companyEntity
 import site.hirecruit.hr.domain.worker.dto.QWorkerDto_Info

--- a/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerCustomRepositoryImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/repository/WorkerCustomRepositoryImpl.kt
@@ -2,7 +2,7 @@ package site.hirecruit.hr.domain.worker.repository
 
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
-import site.hirecruit.hr.domain.auth.entity.QUserEntity.userEntity
+import site.hirecruit.hr.domain.user.entity.QUserEntity.userEntity
 import site.hirecruit.hr.domain.company.dto.QCompanyDto_Info
 import site.hirecruit.hr.domain.company.entity.QCompanyEntity.companyEntity
 import site.hirecruit.hr.domain.worker.dto.QWorkerDto_Info

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImpl.kt
@@ -4,7 +4,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.worker.dto.WorkerDto

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.repository.CompanyRepository

--- a/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImpl.kt
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.entity.Role
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.worker.dto.WorkerDto

--- a/src/main/java/site/hirecruit/hr/global/dummy/SetDummyData.kt
+++ b/src/main/java/site/hirecruit/hr/global/dummy/SetDummyData.kt
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.company.entity.CompanyEntity
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity

--- a/src/main/java/site/hirecruit/hr/global/dummy/SetDummyData.kt
+++ b/src/main/java/site/hirecruit/hr/global/dummy/SetDummyData.kt
@@ -3,8 +3,8 @@ package site.hirecruit.hr.global.dummy
 import net.bytebuddy.utility.RandomString
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.company.entity.CompanyEntity
 import site.hirecruit.hr.domain.company.repository.CompanyRepository

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -14,7 +14,7 @@ import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.authentication.AuthenticationFailureHandler
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.global.data.ServerProfile
 
 private val log = KotlinLogging.logger {  }

--- a/src/main/java/site/hirecruit/hr/global/security/handler/v1_0/OAuthLoginSuccessHandler.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/handler/v1_0/OAuthLoginSuccessHandler.kt
@@ -5,10 +5,8 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler
-import org.springframework.stereotype.Component
-import org.springframework.web.util.UriComponents
 import org.springframework.web.util.UriComponentsBuilder
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
@@ -10,7 +10,7 @@ import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
 import org.springframework.mock.web.MockHttpSession
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.service.SecurityContextAccessService
 import site.hirecruit.hr.domain.auth.service.UserRegistrationService

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
@@ -13,8 +13,9 @@ import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.service.SecurityContextAccessService
-import site.hirecruit.hr.domain.auth.service.UserRegistrationService
+import site.hirecruit.hr.domain.user.service.UserRegistrationService
 import site.hirecruit.hr.domain.test_util.LocalTest
+import site.hirecruit.hr.domain.user.aop.UserRegistrationAspect
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.global.data.SessionAttribute
 import kotlin.random.Random

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserRegistrationAspectTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
 import org.springframework.mock.web.MockHttpSession
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.service.SecurityContextAccessService

--- a/src/test/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspectTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/aop/UserSessionInfoUpdateAspectTest.kt
@@ -10,7 +10,7 @@ import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
 import org.springframework.mock.web.MockHttpSession
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.service.UserAuthService
 import site.hirecruit.hr.domain.auth.service.UserRegistrationRollbackService
 import site.hirecruit.hr.global.data.SessionAttribute

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.impl.OAuth2ProcessorFacadeImpl
 import site.hirecruit.hr.domain.test_util.LocalTest

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/OAuth2ProcessorFacadeImplTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.user.entity.Role
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.impl.OAuth2ProcessorFacadeImpl
 import site.hirecruit.hr.domain.test_util.LocalTest
 import kotlin.random.Random

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.user.entity.Role
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
 import kotlin.random.Random
 

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationRollbackServiceImplTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
 import kotlin.random.Random

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
-import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.global.event.UserRegistrationEvent

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
@@ -12,7 +12,7 @@ import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.user.service.UserRegistrationServiceImpl
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.global.event.UserRegistrationEvent

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
@@ -13,6 +13,7 @@ import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.service.UserRegistrationServiceImpl
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.global.event.UserRegistrationEvent
 import kotlin.random.Random

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserRegistrationServiceTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.dto.UserRegistrationDto
+import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImplTest.kt
@@ -15,7 +15,7 @@ import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.entity.TempUserEntity
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import kotlin.random.Random
 
 internal class UserSessionAuthServiceImplTest{

--- a/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImplTest.kt
@@ -12,7 +12,7 @@ import org.springframework.mock.web.MockHttpSession
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.entity.TempUserEntity
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.auth.repository.UserRepository

--- a/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
@@ -8,7 +8,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.entity.Role
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.mentor.verify.repository.MentorEmailVerificationCodeRepository
 import site.hirecruit.hr.domain.mentor.verify.service.MentorVerificationService

--- a/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/mentor/service/MentorServiceImplTest.kt
@@ -7,7 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.mentor.verify.repository.MentorEmailVerificationCodeRepository

--- a/src/test/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/mentor/verify/service/MentorVerificationServiceImplTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.transaction.annotation.Transactional
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.test_util.LocalTest
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImplTest.kt
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.company.entity.CompanyEntity
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.test_util.LocalTest

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/AuthUserWorkerServiceImplTest.kt
@@ -13,8 +13,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
 import org.springframework.transaction.annotation.Transactional
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.company.entity.CompanyEntity
 import site.hirecruit.hr.domain.company.repository.CompanyRepository

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerLockupServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerLockupServiceImplTest.kt
@@ -6,7 +6,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import site.hirecruit.hr.domain.auth.entity.Role
+import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.domain.worker.dto.WorkerDto
 import site.hirecruit.hr.domain.worker.entity.WorkerEntity

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
-import site.hirecruit.hr.domain.auth.entity.Role
-import site.hirecruit.hr.domain.auth.entity.UserEntity
+import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.user.entity.UserEntity
 import site.hirecruit.hr.domain.auth.repository.UserRepository
 import site.hirecruit.hr.domain.company.entity.CompanyEntity
 import site.hirecruit.hr.domain.company.repository.CompanyRepository

--- a/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
+++ b/src/test/java/site/hirecruit/hr/domain/worker/service/WorkerRegistrationServiceImplTest.kt
@@ -11,7 +11,7 @@ import org.springframework.data.repository.findByIdOrNull
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.user.entity.Role
 import site.hirecruit.hr.domain.user.entity.UserEntity
-import site.hirecruit.hr.domain.auth.repository.UserRepository
+import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.company.entity.CompanyEntity
 import site.hirecruit.hr.domain.company.repository.CompanyRepository
 import site.hirecruit.hr.domain.worker.dto.WorkerDto


### PR DESCRIPTION
## 개요
auth도메인이 너무 커져 auth도메인에서 user도메인을 독립했습니다.

현재 너무 변경사항이 많아 일부만 auth에 있는 일부 user로직들만 독립하였고 여러 pr에 걸쳐 해당 refactoring을 완료할 예정입니다.

## 주요 작업내용
- 회원가입 API를 `auth/registration`에서 `user/registration` 으로 migration준비 했습니다.
    > ac9ced7e5da0f0bad4f5228d99fae3675d97c3c8 커밋을 확인해주세요.
       ![CleanShot 2022-07-06 at 10 11 58@2x](https://user-images.githubusercontent.com/62932968/177442781-cdf01e14-d1c5-43c8-b7c9-51fb41ee12a2.png)
- User관련 DTO auth -> user 이동
    - `UserRegistrationDto`
    - `UserUpdateDto` 
- `UserEntity` auth -> user 이동
- `UserRegistrationService` auth -> user 이동
- User관련 Repository auth -> user 이동
    - `UserRepository`
    - `UserCustomRepository`및 `UserCustomRepositoryImpl`

### 추가적인 작업사항
`UserSessionInfoUpdateAspect`에 추가한 `UserService.update` pointcut을 `setSessionByAuthUserInfo`AOP로직에 명시

<img width="703" alt="CleanShot 2022-07-06 at 10 06 27@2x" src="https://user-images.githubusercontent.com/62932968/177441632-372d305b-f15a-4d66-8099-9f781cd38955.png">

## 앞으로 할 일
- UserUpdateService, UserAuthService auth -> user 도메인 이동
- 지속적인 refactoring

