### PR TITLE
사용자 등록 로직 재설계

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/auth/service/TempUserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/TempUserRegistrationService.kt
@@ -8,6 +8,7 @@ import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
  * @author 정시원
  * @version 1.0
  */
+@Deprecated("해당 인터페이스는 v1.3부터 더 이상 사용되지 않습니다. domain.user.service 패키지에 TempUserRegistrationService로 대체됩니다.")
 interface TempUserRegistrationService {
 
     /**

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/TempUserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/TempUserRegistrationServiceImpl.kt
@@ -13,6 +13,7 @@ import site.hirecruit.hr.domain.auth.service.TempUserRegistrationService
  * @version 1.0
  */
 @Service
+@Deprecated("해당 구현체는 v1.3부터 더 이상 사용하지 않습니다. 해당 구현체의 역할은 domain.user.TempUserService로 이전될 에정입니다.")
 class TempUserRegistrationServiceImpl(
     private val tempUserRepository: TempUserRepository
 ) : TempUserRegistrationService {

--- a/src/main/java/site/hirecruit/hr/domain/user/dto/CommonUserRegistrationDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/dto/CommonUserRegistrationDto.kt
@@ -1,0 +1,14 @@
+package site.hirecruit.hr.domain.user.dto
+
+/**
+ * 사용자 등록 로직에 공통으로 사용되는 Data를 정의한 Maker interface
+ *
+ * @author 정시원
+ * @since 1.3
+ *
+ */
+interface CommonUserRegistrationDto {
+    val githubId: Long
+    val githubLoginId: String
+    val profileImgUri: String
+}

--- a/src/main/java/site/hirecruit/hr/domain/user/dto/RegularUserRegistrationDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/dto/RegularUserRegistrationDto.kt
@@ -1,0 +1,20 @@
+package site.hirecruit.hr.domain.user.dto
+
+import site.hirecruit.hr.domain.user.vo.RegularUserRegistrationRequestVo
+
+/**
+ * 정식 사용자 등록 DTO
+ *
+ * @author 정시원
+ * @since 1.3
+ */
+data class RegularUserRegistrationDto(
+    override val githubId: Long,
+
+    override val githubLoginId: String,
+
+    override val profileImgUri: String,
+
+    val userRegistrationInfo: RegularUserRegistrationRequestVo
+) : CommonUserRegistrationDto {
+}

--- a/src/main/java/site/hirecruit/hr/domain/user/dto/TempUserRegistrationDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/dto/TempUserRegistrationDto.kt
@@ -1,0 +1,13 @@
+package site.hirecruit.hr.domain.user.dto
+
+/**
+ * 임시 사용자 등록 DTO
+ *
+ * @author 정시원
+ * @since 1.3
+ */
+data class TempUserRegistrationDto(
+    override val githubId: Long,
+    override val githubLoginId: String,
+    override val profileImgUri: String
+) : CommonUserRegistrationDto

--- a/src/main/java/site/hirecruit/hr/domain/user/service/NewUserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/NewUserRegistrationService.kt
@@ -1,0 +1,21 @@
+package site.hirecruit.hr.domain.user.service
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.user.dto.CommonUserRegistrationDto
+
+/**
+ * 사용자 등록 서비스 인터페이스
+ *
+ * @author 정시원
+ * @since 1.3
+ */
+interface NewUserRegistrationService<T : CommonUserRegistrationDto> {
+
+
+    /**
+     * 유저를 생성합니다.
+     *
+     * @return 생성된 사용자의 정보
+     */
+    fun registration(registrationDto : T): AuthUserInfo
+}

--- a/src/main/java/site/hirecruit/hr/domain/user/service/RegularUserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/RegularUserRegistrationService.kt
@@ -1,0 +1,54 @@
+package site.hirecruit.hr.domain.user.service
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.user.dto.RegularUserRegistrationDto
+import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.user.entity.UserEntity
+import site.hirecruit.hr.domain.user.repository.UserRepository
+import site.hirecruit.hr.global.event.UserRegistrationEvent
+
+/**
+ * 정식 사용자 등록 서비스
+ *
+ * @author 정시원
+ * @since 1.3
+ */
+@Component
+class RegularUserRegistrationService(
+    private val userRepository: UserRepository,
+    private val publisher: ApplicationEventPublisher
+): NewUserRegistrationService<RegularUserRegistrationDto> {
+
+    /**
+     * 정식 사용자를 등록하는 매서드
+     *
+     * @return 등록된 정식 사용자의 정보
+     */
+    override fun registration(registrationDto: RegularUserRegistrationDto): AuthUserInfo {
+        val savedUserEntity = userRepository.save(
+            UserEntity(
+                githubId = registrationDto.githubId,
+                githubLoginId = registrationDto.githubLoginId,
+                email = registrationDto.userRegistrationInfo.email,
+                name = registrationDto.userRegistrationInfo.name,
+                profileImgUri = registrationDto.profileImgUri,
+                role = Role.WORKER
+            )
+        )
+
+        val registrationAuthUserInfo = AuthUserInfo(
+            githubId = savedUserEntity.githubId,
+            githubLoginId = savedUserEntity.githubLoginId,
+            name = savedUserEntity.name,
+            email = savedUserEntity.email,
+            profileImgUri = savedUserEntity.profileImgUri,
+            role = savedUserEntity.role
+        )
+        // UserRegistrationEvent발생시킴. 타 도메인 로직(ex. workerEntity 생성 등...)은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
+        publisher.publishEvent(UserRegistrationEvent(registrationAuthUserInfo, registrationDto.userRegistrationInfo.workerDto))
+        return registrationAuthUserInfo
+    }
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/user/service/TempUserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/TempUserRegistrationService.kt
@@ -1,0 +1,51 @@
+package site.hirecruit.hr.domain.user.service
+
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.TempUserEntity
+import site.hirecruit.hr.domain.auth.repository.TempUserRepository
+import site.hirecruit.hr.domain.user.dto.TempUserRegistrationDto
+import site.hirecruit.hr.domain.user.entity.Role
+
+/**
+ * 임시 유저 등록 서비스
+ *
+ * @author 정시원
+ * @since 1.3
+ */
+class TempUserRegistrationService(
+    private val tempUserRepository: TempUserRepository
+): NewUserRegistrationService<TempUserRegistrationDto> {
+
+    /**
+     * 임시 사용자 등록 매서드
+     *
+     * @return 이미 등록되었거나 등록한 임시 사용자 정보
+     */
+    override fun registration(registrationDto: TempUserRegistrationDto): AuthUserInfo {
+        if(tempUserRepository.existsById(registrationDto.githubId))
+            return AuthUserInfo(
+                githubId = registrationDto.githubId,
+                githubLoginId = registrationDto.githubLoginId,
+                name = "임시유저",
+                email = null,
+                profileImgUri = registrationDto.profileImgUri,
+                role = Role.GUEST
+            )
+
+        val savedTempUserEntity = tempUserRepository.save(
+            TempUserEntity(
+                githubId = registrationDto.githubId,
+                githubLoginId = registrationDto.githubLoginId,
+                profileImgUri = registrationDto.profileImgUri
+            )
+        )
+        return AuthUserInfo(
+            githubId = savedTempUserEntity.githubId,
+            githubLoginId = savedTempUserEntity.githubLoginId,
+            name = "임시유저",
+            email = null,
+            profileImgUri = savedTempUserEntity.profileImgUri,
+            role = Role.GUEST
+        )
+    }
+}

--- a/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationService.kt
@@ -9,6 +9,7 @@ import site.hirecruit.hr.domain.user.dto.UserRegistrationDto
  * @author 정시원
  * @version 1.0
  */
+@Deprecated("v1.3부터 더 이상 사용하지 않는 유저 등록 서비스 인터페이스 입니다.")
 interface UserRegistrationService {
 
     /**

--- a/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/UserRegistrationServiceImpl.kt
@@ -20,6 +20,7 @@ import site.hirecruit.hr.global.event.UserRegistrationEvent
  * @since 1.0
  */
 @Service
+@Deprecated("v1.3부터 더 이상 사용하지 않는 유저 등록 서비스 입니다. 해당 서비스는 WorkerUserRegistrationService로 대체됩니다.")
 class UserRegistrationServiceImpl(
     private val userRepository: UserRepository,
     private val publisher: ApplicationEventPublisher

--- a/src/main/java/site/hirecruit/hr/domain/user/service/WorkerUserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/WorkerUserRegistrationService.kt
@@ -22,7 +22,7 @@ class WorkerUserRegistrationService(
 ): NewUserRegistrationService<RegularUserRegistrationDto> {
 
     /**
-     * 정식 사용자를 등록하는 매서드
+     * role타입이 [Role.WORKER]인 사용자를 등록하는 매서드
      *
      * @return 등록된 정식 사용자의 정보
      */

--- a/src/main/java/site/hirecruit/hr/domain/user/service/WorkerUserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/WorkerUserRegistrationService.kt
@@ -10,13 +10,13 @@ import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.global.event.UserRegistrationEvent
 
 /**
- * 정식 사용자 등록 서비스
+ * 직장인 유저 등록 서비스
  *
  * @author 정시원
  * @since 1.3
  */
 @Component
-class RegularUserRegistrationService(
+class WorkerUserRegistrationService(
     private val userRepository: UserRepository,
     private val publisher: ApplicationEventPublisher
 ): NewUserRegistrationService<RegularUserRegistrationDto> {
@@ -38,7 +38,7 @@ class RegularUserRegistrationService(
             )
         )
 
-        val registrationAuthUserInfo = AuthUserInfo(
+        val registeredAuthUserInfo = AuthUserInfo(
             githubId = savedUserEntity.githubId,
             githubLoginId = savedUserEntity.githubLoginId,
             name = savedUserEntity.name,
@@ -47,8 +47,8 @@ class RegularUserRegistrationService(
             role = savedUserEntity.role
         )
         // UserRegistrationEvent발생시킴. 타 도메인 로직(ex. workerEntity 생성 등...)은 해당 이벤트의 헨들러가 담당하여 도메인간 느슨한 결합을 유지
-        publisher.publishEvent(UserRegistrationEvent(registrationAuthUserInfo, registrationDto.userRegistrationInfo.workerDto))
-        return registrationAuthUserInfo
+        publisher.publishEvent(UserRegistrationEvent(registeredAuthUserInfo, registrationDto.userRegistrationInfo.workerDto))
+        return registeredAuthUserInfo
     }
 
 }

--- a/src/main/java/site/hirecruit/hr/domain/user/vo/RegularUserRegistrationRequestVo.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/vo/RegularUserRegistrationRequestVo.kt
@@ -1,0 +1,36 @@
+package site.hirecruit.hr.domain.user.vo
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import site.hirecruit.hr.domain.worker.dto.WorkerDto
+import javax.validation.Valid
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+
+/**
+ * 사용자 등록 VO
+ *
+ * @author 정시원
+ * @since 1.3
+ */
+data class RegularUserRegistrationRequestVo(
+
+    @field:NotBlank @field:Email
+    @field:JsonProperty("email")
+    private val _email: String?,
+
+    @field:NotBlank
+    @field:JsonProperty("name")
+    private var _name: String?,
+
+    @field:JsonProperty("worker") @field:NotNull @field:Valid
+    val workerDto: WorkerDto.Registration
+) {
+
+    @get:JsonIgnore
+    val email get() = _email!!
+
+    @get:JsonIgnore
+    val name get() = _name!!
+}


### PR DESCRIPTION
## 개요 
사용자 등록 로직이 확장성이 좋지 않고, `임시 유저 등록`, `정식 유저 등록`(프로필 등록시 사용되는 로직) 로직을 통합하기 위해 사용자 등록 로직을 재설게 했습니다.

## 아키텍처 설계


### 데이터 클래스(DTO, VO)
![UserRegistrationDtoArchitecture](https://user-images.githubusercontent.com/62932968/178137621-967cba3d-964e-4177-8a7c-b936f8e00298.png)

`임시 유저 등록`과 `정식 유저 등록` 로직은 공통으로 `githubId`, `githubLoginId`, `profileImgUri`데이터를 사용합니다. 그래서 이 두가지 로직의 공통 데이터를 선언한 인터페이스 `CommonUserRegistrationDto`를 만들었습니다.
그 하위에는 `임시 유저 등록`에 필요한 Dto(`TempUserRegistrationDto`), `정식 유저 등록`에 필요한 Dto(`RegularUserRegistrationDto`)를 생성하여 `CommonUserRegistrationDto`과 상속관계를 맻었습니다.

### Service 클래스
![UserRegistrationServiceArchitecture](https://user-images.githubusercontent.com/62932968/178138108-6e5cf052-a226-4aba-9711-8e6d280d9c18.png)

`UserRegistrationService`라는 인터페이스는 `CommonUserRegistrationDto`하위 타입으로 가질 수 있는 제네릭 인터페이스를 만들었고, 이를 구현할 때 제네릭에 `CommonUserRegistrationDto`하위 타입을 넘겨주어 `정식 사용자 등록` 로직과 `임시 사용자 등록`로직을 하나의 인터페이스로 통합했습니다.

이렇게 회원가입 유형별 필요한 각각의 Dto를 `CommonUserRegistrationDto`로 상속관계를 통해 묶으면 제네릭을 사용하여 다형성을 사용할 수 있습니다.

## 코드리뷰 원해요
- 네이밍 컨벤션
- 아키텍처 설계

## 앞으로 할 일
- 기존 존재하던 `UserRegistrationService`, `TempUserRegistrationService`를 재설계한 로직으로 교체
- 지속적인 리펙토링
- 테스트 코드
