### PR TITLE
Feature/gha cache lambda trigger

### DIFF
--- a/.github/workflows/trigger-gha-cache-status-script.yml
+++ b/.github/workflows/trigger-gha-cache-status-script.yml
@@ -17,7 +17,7 @@ jobs:
     - name: HTTP Request to gha-cache-status lambda function
       uses: fjogeleit/http-request-action@v1.10.0
       with:
-        url: ${{ secrets.GHA_CACHE_LAMBDA_FUN }}
+        url: ${{ secrets.GHA_CACHE_LAMBDA_FUN_URI }}
         method: 'GET'
     - name: Show Response
       run: |

--- a/.github/workflows/trigger-gha-cache-status-script.yml
+++ b/.github/workflows/trigger-gha-cache-status-script.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: HTTP Request to gha-cache-status lambda function
+      id: request
       uses: fjogeleit/http-request-action@v1.10.0
       with:
         url: ${{ secrets.GHA_CACHE_LAMBDA_FUN_URI }}
         method: 'GET'
     - name: Show Response
       run: |
-        echo ${{ steps.myRequest.outputs.response }}
+        echo ${{ steps.request.outputs.response }}

--- a/.github/workflows/trigger-gha-cache-status-script.yml
+++ b/.github/workflows/trigger-gha-cache-status-script.yml
@@ -2,13 +2,14 @@ name: trigger GHA cache status check lambda function
 
 on:
   pull_request:
+    # CI
     types: [opened, reopened]
     branches:
       - develop
   push:
+    # prod-CD
     branches:
       - master
-      - feature/GHA-CACHE-lambda-trigger
 
 jobs:
   GHA-CACHE-lambda-trigger:

--- a/.github/workflows/trigger-gha-cache-status-script.yml
+++ b/.github/workflows/trigger-gha-cache-status-script.yml
@@ -21,6 +21,3 @@ jobs:
       with:
         url: ${{ secrets.GHA_CACHE_LAMBDA_FUN_URI }}
         method: 'GET'
-    - name: Show Response
-      run: |
-        echo ${{ steps.request.outputs.response }}

--- a/.github/workflows/trigger-gha-cache-status-script.yml
+++ b/.github/workflows/trigger-gha-cache-status-script.yml
@@ -1,0 +1,24 @@
+name: trigger GHA cache status check lambda function
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - develop
+  push:
+    branches:
+      - master
+      - feature/GHA-CACHE-lambda-trigger
+
+jobs:
+  GHA-CACHE-lambda-trigger:
+    runs-on: ubuntu-latest
+    steps:
+    - name: HTTP Request to gha-cache-status lambda function
+      uses: fjogeleit/http-request-action@v1.10.0
+      with:
+        url: ${{ secrets.GHA_CACHE_LAMBDA_FUN }}
+        method: 'GET'
+    - name: Show Response
+      run: |
+        echo ${{ steps.myRequest.outputs.response }}


### PR DESCRIPTION
## 개요

github action active cache storage status 를 보내주는 discord noti function 트리거 workflow 를 개발 함.

## GHA active cache status 구성
`github action (trigger) + aws API Gateway + aws Lambda`

![gha-cache-infra-st](https://user-images.githubusercontent.com/67095821/180928027-78cace6f-866b-407e-9033-ea6f285629cb.png)

## 이후에 할 것
개발하면서 필요한(현재 구성에는 존재하지 않은) 세부 정보들 추가
