### PR TITLE
Update prod redis port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ COPY build/libs/application ./
 RUN true
 
 # Run the jar file
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/hirecruit-1.0.jar","--spring.profiles.active=prod","--redis.host=10.0.4.66"]
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/hirecruit-1.0.jar","--spring.profiles.active=prod","--redis.host=10.0.28.60"]


### PR DESCRIPTION
## 개요
prod는 ECS 컨테이너 기반으로 운영되기 때문에 container run 시 참조하는 `ENTRYPOINT.redis-host` 를 변경 함.