### PR TITLE
MapStruct 도입

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,11 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-batch")
     testImplementation("org.springframework.batch:spring-batch-test")
+
+    /** MapStruct **/
+    implementation("org.mapstruct:mapstruct:1.5.2.Final")
+    kapt("org.mapstruct:mapstruct-processor:1.5.2.Final")
+    kaptTest("org.mapstruct:mapstruct-processor:1.5.2.Final")
 }
 
 /** Querydsl 이 만들어주는 Qclass 경로 지정 **/

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/mapper/AuthUserInfoMapper.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/mapper/AuthUserInfoMapper.kt
@@ -4,6 +4,7 @@ import org.mapstruct.*
 import org.mapstruct.factory.Mappers
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.entity.TempUserEntity
+import site.hirecruit.hr.domain.user.dto.TempUserRegistrationDto
 import site.hirecruit.hr.domain.user.entity.UserEntity
 
 /**
@@ -32,5 +33,11 @@ interface AuthUserInfoMapper {
     )
     fun toAuthUserInfo(tempUserEntity: TempUserEntity): AuthUserInfo
 
+    @Mappings(
+        Mapping(target = "role", expression = "java(Role.GUEST)"),
+        Mapping(target = "name", expression = "java(\"임시유저\")"),
+        Mapping(target = "email", expression = "java(null)")
+    )
+    fun toAuthUserInfo(tempUserRegistrationDto: TempUserRegistrationDto): AuthUserInfo
 
 }

--- a/src/main/java/site/hirecruit/hr/domain/auth/dto/mapper/AuthUserInfoMapper.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/dto/mapper/AuthUserInfoMapper.kt
@@ -1,0 +1,36 @@
+package site.hirecruit.hr.domain.auth.dto.mapper
+
+import org.mapstruct.*
+import org.mapstruct.factory.Mappers
+import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.entity.TempUserEntity
+import site.hirecruit.hr.domain.user.entity.UserEntity
+
+/**
+ * AuthUserInfo의 Mapper class
+ *
+ * @author 정시원
+ * @since 1.2.4
+ */
+@Mapper(
+    componentModel = MappingConstants.ComponentModel.SPRING,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    unmappedTargetPolicy = ReportingPolicy.ERROR,
+)
+interface AuthUserInfoMapper {
+
+    companion object{
+        val INSTANCE: AuthUserInfoMapper = Mappers.getMapper(AuthUserInfoMapper::class.java)
+    }
+
+    fun toAuthUserInfo(userEntity: UserEntity): AuthUserInfo
+
+    @Mappings(
+        Mapping(target = "role", expression = "java(Role.GUEST)"),
+        Mapping(target = "name", expression = "java(\"임시유저\")"),
+        Mapping(target = "email", expression = "java(null)")
+    )
+    fun toAuthUserInfo(tempUserEntity: TempUserEntity): AuthUserInfo
+
+
+}

--- a/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
+++ b/src/main/java/site/hirecruit/hr/domain/auth/service/impl/UserSessionAuthServiceImpl.kt
@@ -5,7 +5,7 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException
 import org.springframework.stereotype.Service
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
 import site.hirecruit.hr.domain.auth.dto.OAuthAttributes
-import site.hirecruit.hr.domain.user.entity.Role
+import site.hirecruit.hr.domain.auth.dto.mapper.AuthUserInfoMapper
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.user.repository.UserRepository
 import site.hirecruit.hr.domain.auth.service.UserAuthService
@@ -43,13 +43,6 @@ open class UserSessionAuthServiceImpl(
     private fun createAuthUserInfoWithTempUserEntity(oAuthAttributes: OAuthAttributes): AuthUserInfo{
         val tempUserEntity = tempUserRepository.findByIdOrNull(oAuthAttributes.id)
             ?: throw OAuth2AuthenticationException("임시 회원의 유효기간이 만료되었거나, 잘못된 회원 정보입니다.")
-        return AuthUserInfo(
-            githubId = tempUserEntity.githubId,
-            githubLoginId = tempUserEntity.githubLoginId,
-            name = "임시유저",
-            email = null,
-            role = Role.GUEST,
-            profileImgUri = tempUserEntity.profileImgUri
-        )
+        return AuthUserInfoMapper.INSTANCE.toAuthUserInfo(tempUserEntity)
     }
 }

--- a/src/main/java/site/hirecruit/hr/domain/user/service/TempUserRegistrationService.kt
+++ b/src/main/java/site/hirecruit/hr/domain/user/service/TempUserRegistrationService.kt
@@ -1,10 +1,10 @@
 package site.hirecruit.hr.domain.user.service
 
 import site.hirecruit.hr.domain.auth.dto.AuthUserInfo
+import site.hirecruit.hr.domain.auth.dto.mapper.AuthUserInfoMapper
 import site.hirecruit.hr.domain.auth.entity.TempUserEntity
 import site.hirecruit.hr.domain.auth.repository.TempUserRepository
 import site.hirecruit.hr.domain.user.dto.TempUserRegistrationDto
-import site.hirecruit.hr.domain.user.entity.Role
 
 /**
  * 임시 유저 등록 서비스
@@ -23,14 +23,7 @@ class TempUserRegistrationService(
      */
     override fun registration(registrationDto: TempUserRegistrationDto): AuthUserInfo {
         if(tempUserRepository.existsById(registrationDto.githubId))
-            return AuthUserInfo(
-                githubId = registrationDto.githubId,
-                githubLoginId = registrationDto.githubLoginId,
-                name = "임시유저",
-                email = null,
-                profileImgUri = registrationDto.profileImgUri,
-                role = Role.GUEST
-            )
+            return AuthUserInfoMapper.INSTANCE.toAuthUserInfo(registrationDto)
 
         val savedTempUserEntity = tempUserRepository.save(
             TempUserEntity(
@@ -39,13 +32,6 @@ class TempUserRegistrationService(
                 profileImgUri = registrationDto.profileImgUri
             )
         )
-        return AuthUserInfo(
-            githubId = savedTempUserEntity.githubId,
-            githubLoginId = savedTempUserEntity.githubLoginId,
-            name = "임시유저",
-            email = null,
-            profileImgUri = savedTempUserEntity.profileImgUri,
-            role = Role.GUEST
-        )
+        return AuthUserInfoMapper.INSTANCE.toAuthUserInfo(savedTempUserEntity)
     }
 }


### PR DESCRIPTION
## 개요
MapStruct를 도입했습니다.
그 예로 `TempUserEntity` to `AuthUserInfo `, `TempUserRegistrationDto`to `AuthUserInfo` 변환하는 코드를 MapStruct로 대체했습니다.

## 해당 pr merge후 해야 하는 일
MapStruct는 annotation processor 기반으로 Mapper class를 생성해주므로 **gradle build를 꼭 해주세요** 그렇지 않으면 application 로직이 제대로 실행되지 않거나 test를 실행할 때 실패할 수 있습니다.

## 앞으로 할 일
- Auth, Worker, User도메인 MapStruct사용