### PR TITLE
refactoring SecurityConfig 클래스의 상수를 properties파일로 분리함

### DIFF
--- a/src/main/java/site/hirecruit/hr/HRApplication.kt
+++ b/src/main/java/site/hirecruit/hr/HRApplication.kt
@@ -1,8 +1,8 @@
 package site.hirecruit.hr
 
 import mu.KotlinLogging
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
 import java.time.LocalDateTime
 import java.util.*
@@ -11,7 +11,7 @@ import javax.annotation.PostConstruct
 private val log = KotlinLogging.logger {}
 
 @SpringBootApplication
-@EnableBatchProcessing
+@ConfigurationPropertiesScan
 class HRApplication {
 
     @PostConstruct

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -29,16 +29,14 @@ private val log = KotlinLogging.logger {  }
  */
 @Configuration
 class SecurityConfig(
+    private val properties: SecurityProperty,
+
     private val oauth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
     private val authenticationSuccessHandler: AuthenticationSuccessHandler,
     private val logoutSuccessHandler: LogoutSuccessHandler,
     private val authenticationFailureHandler: AuthenticationFailureHandler,
     private val authenticationEntryPoint: AuthenticationEntryPoint
 ) {
-
-    private val oauth2LoginEndpointBaseUri = "/api/v1/auth/oauth2/authorization"
-    private val oauth2LoginRedirectionEndpointBaseUri = "/api/v1/auth/oauth2/redirection-endpoint"
-
     private fun logoutConfig(http: HttpSecurity) = http
             .logout()
             .logoutUrl("/api/v1/auth/logout")
@@ -85,10 +83,10 @@ class SecurityConfig(
                 it.userService(oauth2UserService)
             }
             oauth2Login.authorizationEndpoint{ authorizationEndPoint ->
-                authorizationEndPoint.baseUri(oauth2LoginEndpointBaseUri) // oauth2 로그인 최초 진입점
+                authorizationEndPoint.baseUri(properties.oauth2.loginEndpointBaseUri) // oauth2 로그인 최초 진입점
             }
             oauth2Login.redirectionEndpoint{ redirectEndPoint ->
-                redirectEndPoint.baseUri(oauth2LoginRedirectionEndpointBaseUri)
+                redirectEndPoint.baseUri(properties.oauth2.loginRedirectionEndpointBaseUri)
             }
             oauth2Login.successHandler(authenticationSuccessHandler)
             oauth2Login.failureHandler(authenticationFailureHandler)

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -39,7 +39,7 @@ class SecurityConfig(
 ) {
     private fun logoutConfig(http: HttpSecurity) = http
             .logout()
-            .logoutUrl("/api/v1/auth/logout")
+            .logoutUrl(properties.authentication.logoutUrl)
             .logoutSuccessHandler(logoutSuccessHandler)
 
 

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityConfig.kt
@@ -29,7 +29,7 @@ private val log = KotlinLogging.logger {  }
  */
 @Configuration
 class SecurityConfig(
-    private val properties: SecurityProperty,
+    private val properties: SecurityProperties,
 
     private val oauth2UserService: OAuth2UserService<OAuth2UserRequest, OAuth2User>,
     private val authenticationSuccessHandler: AuthenticationSuccessHandler,

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityProperties.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityProperties.kt
@@ -13,11 +13,16 @@ import org.springframework.boot.context.properties.ConstructorBinding
 @ConstructorBinding
 @ConfigurationProperties(prefix = "security")
 data class SecurityProperties(
-    val oauth2: OAuth2Properties
+    val oauth2: OAuth2Properties,
+    val authentication: AuthenticationProperties
 ) {
 
     data class OAuth2Properties(
         val loginEndpointBaseUri: String,
         val loginRedirectionEndpointBaseUri: String
+    )
+
+    data class AuthenticationProperties(
+        val logoutUrl: String
     )
 }

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityProperties.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityProperties.kt
@@ -3,9 +3,16 @@ package site.hirecruit.hr.global.security
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 
+/**
+ * security 관련 properties를 바인딩 한 클래스
+ * resources/properties/security.yml 참고
+ *
+ * @author 정시원
+ * @since v1.3.0
+ */
 @ConstructorBinding
 @ConfigurationProperties(prefix = "security")
-data class SecurityProperty(
+data class SecurityProperties(
     val oauth2: OAuth2Properties
 ) {
 

--- a/src/main/java/site/hirecruit/hr/global/security/SecurityProperty.kt
+++ b/src/main/java/site/hirecruit/hr/global/security/SecurityProperty.kt
@@ -1,0 +1,16 @@
+package site.hirecruit.hr.global.security
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "security")
+data class SecurityProperty(
+    val oauth2: OAuth2Properties
+) {
+
+    data class OAuth2Properties(
+        val loginEndpointBaseUri: String,
+        val loginRedirectionEndpointBaseUri: String
+    )
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,7 +16,9 @@ server:
 
 spring:
   config:
-    import: classpath:oauth/github-oauth-local.yml
+    import:
+      - classpath:oauth/github-oauth-local.yml
+      - classpath:properties/security.yml
 
   batch:
     job:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,7 +18,9 @@ server:
 
 spring:
   config:
-    import: classpath:oauth/github-oauth.yml
+    import:
+      - classpath:oauth/github-oauth.yml
+      - classpath:properties/security.yml
 
   mvc:
     path match:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -18,7 +18,9 @@ server:
 
 spring:
   config:
-    import: classpath:oauth/github-oauth-staging.yml
+    import:
+      - classpath:oauth/github-oauth-staging.yml
+      - classpath:properties/security.yml
 
   batch:
     job:

--- a/src/main/resources/properties/security.yml
+++ b/src/main/resources/properties/security.yml
@@ -1,0 +1,4 @@
+security:
+  oauth2:
+    loginEndpointBaseUri: /api/v1/auth/oauth2/authorization
+    loginRedirectionEndpointBaseUri: /api/v1/auth/oauth2/redirection-endpoint

--- a/src/main/resources/properties/security.yml
+++ b/src/main/resources/properties/security.yml
@@ -1,4 +1,7 @@
 security:
+  authentication:
+    logoutUrl: /api/v1/auth/logout
+
   oauth2:
     loginEndpointBaseUri: /api/v1/auth/oauth2/authorization
     loginRedirectionEndpointBaseUri: /api/v1/auth/oauth2/redirection-endpoint


### PR DESCRIPTION
## 개요
제목과 같이 `SecurityConfig` 클래스에서 사용하던 상수를 properties파일로 분리하고 `SecurityProperties`클래스로 매핑했습니다.
