### PR TITLE
hotfix/springfox-issue

### DIFF
--- a/src/main/java/site/hirecruit/hr/domain/career/CareerEntity.kt
+++ b/src/main/java/site/hirecruit/hr/domain/career/CareerEntity.kt
@@ -27,7 +27,7 @@ class CareerEntity(
     val beginDate: LocalDate,
 
     @Column(name = "end_date")
-    val endDate: LocalDate,
+    val endDate: LocalDate? = null,
 
     @Column(name = "in_office_yn")
     val inOfficeYN: YnType,

--- a/src/main/java/site/hirecruit/hr/domain/career/controller/CareerController.kt
+++ b/src/main/java/site/hirecruit/hr/domain/career/controller/CareerController.kt
@@ -11,6 +11,7 @@ import site.hirecruit.hr.domain.career.dto.CareerDto
 import site.hirecruit.hr.domain.career.service.CareerService
 import site.hirecruit.hr.global.annotation.CurrentAuthUserInfo
 import springfox.documentation.annotations.ApiIgnore
+import javax.validation.Valid
 
 /**
  * @author 전지환 이용권&정산유닛 (jyeonjyan@sk.com)
@@ -22,9 +23,9 @@ class CareerController(
     val careerService: CareerService
 ) {
 
-    @PostMapping("")
+    @PostMapping
     fun createCareer(
-        @RequestBody create: CareerDto.Create,
+        @RequestBody @Valid create: CareerDto.Create,
         @CurrentAuthUserInfo @ApiIgnore authUserInfo: AuthUserInfo
     ) : ResponseEntity<CareerDto.Info> {
         return ResponseEntity.ok().body(careerService.createCareer(create, authUserInfo.githubId))

--- a/src/main/java/site/hirecruit/hr/domain/career/dto/CareerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/career/dto/CareerDto.kt
@@ -1,6 +1,7 @@
 package site.hirecruit.hr.domain.career.dto
 
-import io.swagger.annotations.ApiModelProperty
+import io.swagger.annotations.ApiModel
+import io.swagger.v3.oas.annotations.media.Schema
 import site.hirecruit.hr.domain.career.CareerEntity
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.global.util.YnType
@@ -11,8 +12,9 @@ import java.time.LocalDate
  */
 class CareerDto {
 
-    class Create(
-        @ApiModelProperty(value = "companyId", position = 1)
+    @ApiModel("CareerCreateDto")
+    data class Create(
+        @field:NotBlank
         val companyId: Long,
         @ApiModelProperty(value = "position", position = 2)
         val position: String,

--- a/src/main/java/site/hirecruit/hr/domain/career/dto/CareerDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/career/dto/CareerDto.kt
@@ -6,6 +6,7 @@ import site.hirecruit.hr.domain.career.CareerEntity
 import site.hirecruit.hr.domain.company.dto.CompanyDto
 import site.hirecruit.hr.global.util.YnType
 import java.time.LocalDate
+import javax.validation.constraints.NotBlank
 
 /**
  * @author 전지환 이용권&정산유닛 (jyeonjyan@sk.com)
@@ -16,15 +17,15 @@ class CareerDto {
     data class Create(
         @field:NotBlank
         val companyId: Long,
-        @ApiModelProperty(value = "position", position = 2)
+        @field:NotBlank
         val position: String,
-        @ApiModelProperty(value = "beginDate", position = 3)
+        @field:NotBlank
         val beginDate: LocalDate,
-        @ApiModelProperty(value = "endDate", position = 4)
-        val endDate: LocalDate,
-        @ApiModelProperty(value = "inOfficeYN", position = 4)
+        @field:Schema(description = "nullable, default null :: 가장 최근의 커리어로 판단함.")
+        val endDate: LocalDate? = null,
+        @field:NotBlank
         val inOfficeYN: YnType,
-        @ApiModelProperty(value = "disclosureStatus", position = 5)
+        @field:NotBlank
         val disclosureStatus: YnType
     ){ }
 
@@ -33,7 +34,7 @@ class CareerDto {
         val companyInfo: CompanyDto.Info,
         val position: String,
         val beginDate: LocalDate,
-        val endDate: LocalDate,
+        val endDate: LocalDate? = null,
         val inOfficeYN: YnType,
         val disclosureStatus: YnType,
         val deleteStatus: YnType

--- a/src/main/java/site/hirecruit/hr/domain/company/dto/CompanyDto.kt
+++ b/src/main/java/site/hirecruit/hr/domain/company/dto/CompanyDto.kt
@@ -3,6 +3,7 @@ package site.hirecruit.hr.domain.company.dto
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.querydsl.core.annotations.QueryProjection
+import io.swagger.annotations.ApiModel
 import org.hibernate.validator.constraints.URL
 import site.hirecruit.hr.domain.company.validator.annoation.CompanyNotDuplicate
 import javax.validation.constraints.NotBlank
@@ -18,6 +19,7 @@ class CompanyDto {
     )
 
     @CompanyNotDuplicate
+    @ApiModel(value = "CompanyCreateDto")
     data class Create(
         @field:JsonProperty("name") @field:NotBlank
         val _name: String?,


### PR DESCRIPTION
## 작업내용
* springfox library의 [잔존(?)이슈](https://github.com/springfox/springfox/issues/182) 해결
  * location 과 관련없이 같은 이름의 클래스가 project에 공존할 때 `@RequestBody` 대상(클래스)을 정확히 발견하지 못함.
* 누락된 validation field 추가
* `endDate` 에 대해 not null data -> nullable data 로 변경함.